### PR TITLE
Refactor active skills to use centralized data definitions

### DIFF
--- a/src/module/actor/prep/SpiritPrep.ts
+++ b/src/module/actor/prep/SpiritPrep.ts
@@ -6,8 +6,8 @@ import { WoundsPrep } from './functions/WoundsPrep';
 import { ModifiersPrep } from './functions/ModifiersPrep';
 import { InitiativePrep } from './functions/InitiativePrep';
 import { Helpers } from '../../helpers';
-import { PartsList } from "../../parts/PartsList";
-import { SkillFlow } from "../flows/SkillFlow";
+import { PartsList } from '../../parts/PartsList';
+import { SkillFlow } from '../flows/SkillFlow';
 import { CharacterPrep } from './CharacterPrep';
 import { GruntPrep } from './functions/GruntPrep';
 import { DataDefaults } from '../../data/DataDefaults';
@@ -16,7 +16,7 @@ import { SR } from '../../constants';
 import { SkillFieldType, SkillsType } from 'src/module/types/template/Skills';
 import { SR5Item } from 'src/module/item/SR5Item';
 import { AttributesType } from 'src/module/types/template/Attributes';
-
+import { ActiveSkillsById } from '../../config/ActiveSkills';
 
 export class SpiritPrep {
     static prepareBaseData(system: Actor.SystemOfType<'spirit'>) {
@@ -83,15 +83,35 @@ export class SpiritPrep {
             }
 
             // prepare initiative data
-            initiative.meatspace.base.base = force * overrides.init_mult + overrides.init + Number(modifiers['astral_initiative']);
-            initiative.meatspace.base.mod = PartsList.AddUniquePart(initiative.meatspace.base.mod, "SR5.Bonus", Number(modifiers['meat_initiative']));
+            initiative.meatspace.base.base =
+                force * overrides.init_mult + overrides.init + Number(modifiers['astral_initiative']);
+            initiative.meatspace.base.mod = PartsList.AddUniquePart(
+                initiative.meatspace.base.mod,
+                'SR5.Bonus',
+                Number(modifiers['meat_initiative']),
+            );
             initiative.meatspace.dice.base = overrides.init_dice;
-            initiative.meatspace.dice.mod = PartsList.AddUniquePart(initiative.meatspace.dice.mod, "SR5.Bonus", Number(modifiers['meat_initiative_dice']));
+            initiative.meatspace.dice.mod = PartsList.AddUniquePart(
+                initiative.meatspace.dice.mod,
+                'SR5.Bonus',
+                Number(modifiers['meat_initiative_dice']),
+            );
 
-            initiative.astral.base.base = force * overrides.astral_init_mult + overrides.astral_init + Number(modifiers['astral_initiative_dice']);
-            initiative.astral.base.mod = PartsList.AddUniquePart(initiative.astral.base.mod, "SR5.Bonus", Number(modifiers['astral_initiative']));
+            initiative.astral.base.base =
+                force * overrides.astral_init_mult +
+                overrides.astral_init +
+                Number(modifiers['astral_initiative_dice']);
+            initiative.astral.base.mod = PartsList.AddUniquePart(
+                initiative.astral.base.mod,
+                'SR5.Bonus',
+                Number(modifiers['astral_initiative']),
+            );
             initiative.astral.dice.base = overrides.astral_init_dice;
-            initiative.astral.dice.mod = PartsList.AddUniquePart(initiative.astral.dice.mod, "SR5.Bonus", Number(modifiers['astral_initiative_dice']));
+            initiative.astral.dice.mod = PartsList.AddUniquePart(
+                initiative.astral.dice.mod,
+                'SR5.Bonus',
+                Number(modifiers['astral_initiative_dice']),
+            );
         }
     }
 
@@ -104,10 +124,12 @@ export class SpiritPrep {
     static prepareActiveSkill(skillId: string, skills: SkillsType): SkillFieldType {
         if (skills[skillId]) return skills[skillId];
 
-        const label = SR5.activeSkills[skillId];
-        const attribute = SR5.activeSkillAttribute[skillId];
+        const rawSkill = ActiveSkillsById[skillId];
+        const label = rawSkill.label;
+        const attribute = rawSkill.linkedAttribute;
+        const canDefault = rawSkill.flags.canDefault;
 
-        return DataDefaults.createData('skill_field', { label, attribute, canDefault: false })
+        return DataDefaults.createData('skill_field', { label, attribute, canDefault });
     }
 
     static prepareSpiritArmor(system: Actor.SystemOfType<'spirit'>) {
@@ -147,7 +169,7 @@ export class SpiritPrep {
             astral_init_dice: 3,
             // skills are all set to Force
             skills: [] as string[],
-            halfValueSkill: false as boolean
+            halfValueSkill: false as boolean,
         };
         switch (spiritType) {
             case 'air':
@@ -171,7 +193,15 @@ export class SpiritPrep {
                 overrides.attributes.reaction = 4;
                 overrides.attributes.strength = -3;
                 overrides.init = 4;
-                overrides.skills.push('assensing', 'astral_combat', 'exotic_range', 'impersonation', 'perception', 'running', 'unarmed_combat');
+                overrides.skills.push(
+                    'assensing',
+                    'astral_combat',
+                    'exotic_range',
+                    'impersonation',
+                    'perception',
+                    'running',
+                    'unarmed_combat',
+                );
                 break;
             case 'ally':
                 overrides.skills.push('assensing', 'astral_combat', 'perception', 'unarmed_combat');
@@ -196,7 +226,14 @@ export class SpiritPrep {
                 overrides.attributes.strength = -1;
                 overrides.attributes.charisma = 1;
                 overrides.init = 2;
-                overrides.skills.push('assensing', 'astral_combat', 'counterspelling', 'impersonation', 'perception', 'unarmed_combat');
+                overrides.skills.push(
+                    'assensing',
+                    'astral_combat',
+                    'counterspelling',
+                    'impersonation',
+                    'perception',
+                    'unarmed_combat',
+                );
                 break;
             case 'bone':
                 overrides.attributes.body = 3;
@@ -236,7 +273,14 @@ export class SpiritPrep {
                 overrides.attributes.strength = -2;
                 overrides.attributes.intuition = 1;
                 overrides.init = 3;
-                overrides.skills.push('assensing', 'astral_combat', 'exotic_range', 'flight', 'perception', 'unarmed_combat');
+                overrides.skills.push(
+                    'assensing',
+                    'astral_combat',
+                    'exotic_range',
+                    'flight',
+                    'perception',
+                    'unarmed_combat',
+                );
                 break;
             case 'guardian':
                 overrides.attributes.body = 1;
@@ -244,14 +288,30 @@ export class SpiritPrep {
                 overrides.attributes.reaction = 3;
                 overrides.attributes.strength = 2;
                 overrides.init = 1;
-                overrides.skills.push('assensing', 'astral_combat', 'blades', 'clubs', 'counterspelling', 'exotic_range', 'perception', 'unarmed_combat');
+                overrides.skills.push(
+                    'assensing',
+                    'astral_combat',
+                    'blades',
+                    'clubs',
+                    'counterspelling',
+                    'exotic_range',
+                    'perception',
+                    'unarmed_combat',
+                );
                 break;
             case 'guidance':
                 overrides.attributes.body = 3;
                 overrides.attributes.agility = -1;
                 overrides.attributes.reaction = 2;
                 overrides.attributes.strength = 1;
-                overrides.skills.push('arcana', 'assensing', 'astral_combat', 'counterspelling', 'perception', 'unarmed_combat');
+                overrides.skills.push(
+                    'arcana',
+                    'assensing',
+                    'astral_combat',
+                    'counterspelling',
+                    'perception',
+                    'unarmed_combat',
+                );
                 break;
             case 'homunculus':
                 delete overrides.attributes.body;
@@ -300,7 +360,14 @@ export class SpiritPrep {
                 overrides.attributes.strength = 2;
                 overrides.attributes.logic = -2;
                 overrides.init = -1;
-                overrides.skills.push('navigation', 'perception', 'pilot_water_craft', 'survival', 'swimming', 'unarmed_combat');
+                overrides.skills.push(
+                    'navigation',
+                    'perception',
+                    'pilot_water_craft',
+                    'survival',
+                    'swimming',
+                    'unarmed_combat',
+                );
                 break;
             case 'task':
                 overrides.attributes.reaction = 2;
@@ -316,7 +383,13 @@ export class SpiritPrep {
                 overrides.attributes.willpower = 1;
                 overrides.attributes.logic = -2;
                 overrides.init = -1;
-                overrides.skills.push('intimidation', 'navigation', 'perception', 'pilot_ground_craft', 'unarmed_combat');
+                overrides.skills.push(
+                    'intimidation',
+                    'navigation',
+                    'perception',
+                    'pilot_ground_craft',
+                    'unarmed_combat',
+                );
                 break;
             case 'watcher':
                 delete overrides.attributes.body;
@@ -346,13 +419,28 @@ export class SpiritPrep {
                 overrides.attributes.reaction = 4;
                 overrides.attributes.strength = -3;
                 overrides.init = 4;
-                overrides.skills.push('assensing', 'astral_combat', 'exotic_range', 'perception', 'running', 'unarmed_combat');
+                overrides.skills.push(
+                    'assensing',
+                    'astral_combat',
+                    'exotic_range',
+                    'perception',
+                    'running',
+                    'unarmed_combat',
+                );
                 break;
             case 'toxic_beasts':
                 overrides.attributes.body = 2;
                 overrides.attributes.agility = 1;
                 overrides.attributes.strength = 2;
-                overrides.skills.push('assensing', 'astral_combat', 'exotic_range', 'gymnastics', 'perception', 'running', 'unarmed_combat');
+                overrides.skills.push(
+                    'assensing',
+                    'astral_combat',
+                    'exotic_range',
+                    'gymnastics',
+                    'perception',
+                    'running',
+                    'unarmed_combat',
+                );
                 break;
             case 'toxic_earth':
                 overrides.attributes.body = 4;
@@ -370,7 +458,14 @@ export class SpiritPrep {
                 overrides.attributes.strength = -2;
                 overrides.attributes.intuition = 1;
                 overrides.init = 3;
-                overrides.skills.push('assensing', 'astral_combat', 'exotic_range', 'perception', 'flight', 'unarmed_combat');
+                overrides.skills.push(
+                    'assensing',
+                    'astral_combat',
+                    'exotic_range',
+                    'perception',
+                    'flight',
+                    'unarmed_combat',
+                );
                 break;
             case 'toxic_man':
                 overrides.attributes.reaction = 2;
@@ -400,7 +495,15 @@ export class SpiritPrep {
                 overrides.attributes.reaction = 2;
                 overrides.attributes.willpower = 1;
                 overrides.init = 3;
-                overrides.skills.push('assensing', 'astral_combat', 'con', 'gymnastics', 'intimidation', 'perception', 'unarmed_combat');
+                overrides.skills.push(
+                    'assensing',
+                    'astral_combat',
+                    'con',
+                    'gymnastics',
+                    'intimidation',
+                    'perception',
+                    'unarmed_combat',
+                );
                 break;
             case 'nightmare':
                 overrides.attributes.agility = 3;
@@ -409,7 +512,15 @@ export class SpiritPrep {
                 overrides.attributes.intuition = 1;
                 overrides.attributes.charisma = 2;
                 overrides.init = 3;
-                overrides.skills.push('assensing', 'astral_combat', 'con', 'gymnastics', 'intimidation', 'perception', 'unarmed_combat');
+                overrides.skills.push(
+                    'assensing',
+                    'astral_combat',
+                    'con',
+                    'gymnastics',
+                    'intimidation',
+                    'perception',
+                    'unarmed_combat',
+                );
                 break;
             case 'shade':
                 overrides.attributes.agility = 3;
@@ -418,7 +529,15 @@ export class SpiritPrep {
                 overrides.attributes.intuition = 1;
                 overrides.attributes.charisma = 2;
                 overrides.init = 3;
-                overrides.skills.push('assensing', 'astral_combat', 'con', 'gymnastics', 'intimidation', 'perception', 'unarmed_combat');
+                overrides.skills.push(
+                    'assensing',
+                    'astral_combat',
+                    'con',
+                    'gymnastics',
+                    'intimidation',
+                    'perception',
+                    'unarmed_combat',
+                );
                 break;
             case 'succubus':
                 overrides.attributes.agility = 3;
@@ -427,7 +546,15 @@ export class SpiritPrep {
                 overrides.attributes.intuition = 1;
                 overrides.attributes.charisma = 2;
                 overrides.init = 3;
-                overrides.skills.push('assensing', 'astral_combat', 'con', 'gymnastics', 'intimidation', 'perception', 'unarmed_combat');
+                overrides.skills.push(
+                    'assensing',
+                    'astral_combat',
+                    'con',
+                    'gymnastics',
+                    'intimidation',
+                    'perception',
+                    'unarmed_combat',
+                );
                 break;
             case 'wraith':
                 overrides.attributes.agility = 3;
@@ -436,7 +563,15 @@ export class SpiritPrep {
                 overrides.attributes.intuition = 1;
                 overrides.attributes.charisma = 2;
                 overrides.init = 3;
-                overrides.skills.push('assensing', 'astral_combat', 'con', 'gymnastics', 'intimidation', 'perception', 'unarmed_combat');
+                overrides.skills.push(
+                    'assensing',
+                    'astral_combat',
+                    'con',
+                    'gymnastics',
+                    'intimidation',
+                    'perception',
+                    'unarmed_combat',
+                );
                 break;
 
             // Shedim
@@ -453,7 +588,17 @@ export class SpiritPrep {
                 overrides.attributes.intuition = 1;
                 overrides.init = 6;
                 overrides.init_dice = 1;
-                overrides.skills.push('assensing', 'astral_combat', 'blades', 'gymnastics', 'perception', 'running', 'sneaking', 'throwing_weapons', 'unarmed_combat');
+                overrides.skills.push(
+                    'assensing',
+                    'astral_combat',
+                    'blades',
+                    'gymnastics',
+                    'perception',
+                    'running',
+                    'sneaking',
+                    'throwing_weapons',
+                    'unarmed_combat',
+                );
                 break;
 
             case 'blade_summoned':
@@ -463,7 +608,17 @@ export class SpiritPrep {
                 overrides.attributes.strength = 1;
                 overrides.init = 2;
                 overrides.init_dice = 1;
-                overrides.skills.push('assensing', 'astral_combat', 'blades', 'gymnastics', 'perception', 'running', 'sneaking', 'throwing_weapons', 'unarmed_combat');
+                overrides.skills.push(
+                    'assensing',
+                    'astral_combat',
+                    'blades',
+                    'gymnastics',
+                    'perception',
+                    'running',
+                    'sneaking',
+                    'throwing_weapons',
+                    'unarmed_combat',
+                );
                 break;
 
             case 'horror_show':
@@ -473,7 +628,19 @@ export class SpiritPrep {
                 overrides.attributes.strength = 1;
                 overrides.init = 2;
                 overrides.init_dice = 1;
-                overrides.skills.push('assensing', 'astral_combat', 'blades', 'con', 'disguise', 'gymnastics', 'impersonation', 'perception', 'running', 'sneaking', 'unarmed_combat');
+                overrides.skills.push(
+                    'assensing',
+                    'astral_combat',
+                    'blades',
+                    'con',
+                    'disguise',
+                    'gymnastics',
+                    'impersonation',
+                    'perception',
+                    'running',
+                    'sneaking',
+                    'unarmed_combat',
+                );
                 break;
 
             case 'unbreakable':
@@ -484,7 +651,15 @@ export class SpiritPrep {
                 overrides.attributes.logic = -1;
                 overrides.init = 1;
                 overrides.init_dice = 1;
-                overrides.skills.push('assensing', 'astral_combat', 'clubs', 'perception', 'sneaking', 'throwing_weapons', 'unarmed_combat');
+                overrides.skills.push(
+                    'assensing',
+                    'astral_combat',
+                    'clubs',
+                    'perception',
+                    'sneaking',
+                    'throwing_weapons',
+                    'unarmed_combat',
+                );
                 break;
 
             case 'master_shedim':
@@ -494,7 +669,14 @@ export class SpiritPrep {
                 overrides.attributes.intuition = 1;
                 overrides.init = 3;
                 overrides.init_dice = 1;
-                overrides.skills.push('assensing', 'astral_combat', 'counterspelling', 'perception', 'spellcasting', 'unarmed_combat');
+                overrides.skills.push(
+                    'assensing',
+                    'astral_combat',
+                    'counterspelling',
+                    'perception',
+                    'spellcasting',
+                    'unarmed_combat',
+                );
                 break;
 
             // insect
@@ -509,13 +691,27 @@ export class SpiritPrep {
                 overrides.attributes.reaction = 3;
                 overrides.attributes.strength = 1;
                 overrides.init = 3;
-                overrides.skills.push('assensing', 'astral_combat', 'perception', 'gymnastics', 'spellcasting', 'unarmed_combat');
+                overrides.skills.push(
+                    'assensing',
+                    'astral_combat',
+                    'perception',
+                    'gymnastics',
+                    'spellcasting',
+                    'unarmed_combat',
+                );
                 break;
             case 'scout':
                 overrides.attributes.agility = 2;
                 overrides.attributes.reaction = 2;
                 overrides.init = 2;
-                overrides.skills.push('assensing', 'astral_combat', 'perception', 'gymnastics', 'sneaking', 'unarmed_combat');
+                overrides.skills.push(
+                    'assensing',
+                    'astral_combat',
+                    'perception',
+                    'gymnastics',
+                    'sneaking',
+                    'unarmed_combat',
+                );
                 break;
             case 'soldier':
                 overrides.attributes.body = 3;
@@ -523,7 +719,15 @@ export class SpiritPrep {
                 overrides.attributes.reaction = 1;
                 overrides.attributes.strength = 3;
                 overrides.init = 1;
-                overrides.skills.push('assensing', 'astral_combat', 'counterspelling', 'exotic_range', 'gymnastics', 'perception', 'unarmed_combat');
+                overrides.skills.push(
+                    'assensing',
+                    'astral_combat',
+                    'counterspelling',
+                    'exotic_range',
+                    'gymnastics',
+                    'perception',
+                    'unarmed_combat',
+                );
                 break;
             case 'worker':
                 overrides.attributes.strength = 1;
@@ -538,15 +742,26 @@ export class SpiritPrep {
                 overrides.attributes.logic = 1;
                 overrides.attributes.intuition = 1;
                 overrides.init = 5;
-                overrides.skills.push('assensing', 'astral_combat', 'con', 'counterspelling', 'gymnastics', 'leadership', 'negotiation', 'perception', 'spellcasting', 'unarmed_combat' );
+                overrides.skills.push(
+                    'assensing',
+                    'astral_combat',
+                    'con',
+                    'counterspelling',
+                    'gymnastics',
+                    'leadership',
+                    'negotiation',
+                    'perception',
+                    'spellcasting',
+                    'unarmed_combat',
+                );
                 break;
-            case "carcass":
+            case 'carcass':
                 overrides.attributes.body = 3;
                 overrides.attributes.strength = 2;
                 overrides.attributes.charisma = -1;
-                overrides.skills.push("assensing", "astral_combat", "perception", "unarmed_combat");
+                overrides.skills.push('assensing', 'astral_combat', 'perception', 'unarmed_combat');
                 break;
-            case "corpse":
+            case 'corpse':
                 overrides.attributes.body = 2;
                 overrides.attributes.agility = -1;
                 overrides.attributes.reaction = 2;
@@ -554,17 +769,24 @@ export class SpiritPrep {
                 overrides.attributes.intuition = 1;
                 overrides.attributes.charisma = -1;
                 overrides.init = 2;
-                overrides.skills.push("assensing", "astral_combat", "perception", "unarmed_combat");
+                overrides.skills.push('assensing', 'astral_combat', 'perception', 'unarmed_combat');
                 break;
-            case "rot":
+            case 'rot':
                 overrides.attributes.body = 3;
                 overrides.attributes.agility = -2;
                 overrides.attributes.strength = 1;
                 overrides.attributes.logic = -1;
                 overrides.attributes.charisma = -1;
-                overrides.skills.push("assensing", "astral_combat", "counterspelling", "exotic_range", "perception", "unarmed_combat");
+                overrides.skills.push(
+                    'assensing',
+                    'astral_combat',
+                    'counterspelling',
+                    'exotic_range',
+                    'perception',
+                    'unarmed_combat',
+                );
                 break;
-            case "palefile":
+            case 'palefile':
                 overrides.attributes.body = 2;
                 overrides.attributes.agility = 1;
                 overrides.attributes.reaction = 3;
@@ -572,9 +794,16 @@ export class SpiritPrep {
                 overrides.attributes.intuition = 1;
                 overrides.attributes.charisma = -1;
                 overrides.init = 3;
-                overrides.skills.push("assensing", "astral_combat", "exotic_range", "flight", "perception", "unarmed_combat");
+                overrides.skills.push(
+                    'assensing',
+                    'astral_combat',
+                    'exotic_range',
+                    'flight',
+                    'perception',
+                    'unarmed_combat',
+                );
                 break;
-            case "detritus":
+            case 'detritus':
                 overrides.attributes.body = 5;
                 overrides.attributes.agility = -3;
                 overrides.attributes.reaction = -1;
@@ -582,194 +811,367 @@ export class SpiritPrep {
                 overrides.attributes.logic = -1;
                 overrides.attributes.charisma = -1;
                 overrides.init = -1;
-                overrides.skills.push("assensing", "astral_combat", "exotic_range", "perception", "unarmed_combat");
+                overrides.skills.push('assensing', 'astral_combat', 'exotic_range', 'perception', 'unarmed_combat');
                 break;
 
             // Howling Shadow
-            case "anarch":
+            case 'anarch':
                 overrides.attributes.body = -1;
                 overrides.attributes.agility = -1;
                 overrides.attributes.reaction = 1;
                 overrides.attributes.strength = -1;
                 overrides.init = 1;
-                overrides.skills.push("assensing", "automatics", "blades", "clubs", "con", "demolitions", "disguise", "forgery", "gymnastics", "impersonation", "locksmith", "palming", "perception", "pistols", "sneaking", "throwing_weapons", "unarmed_combat");
+                overrides.skills.push(
+                    'assensing',
+                    'automatics',
+                    'blades',
+                    'clubs',
+                    'con',
+                    'demolitions',
+                    'disguise',
+                    'forgery',
+                    'gymnastics',
+                    'impersonation',
+                    'locksmith',
+                    'palming',
+                    'perception',
+                    'pistols',
+                    'sneaking',
+                    'throwing_weapons',
+                    'unarmed_combat',
+                );
                 break;
 
-            case "arboreal":
+            case 'arboreal':
                 overrides.attributes.body = +2;
                 overrides.attributes.strength = 1;
                 overrides.attributes.essence = -2;
-                overrides.skills.push("assensing", "astral_combat", "blade", "clubs", "unarmed_combat", "exotic_range", "perception");
+                overrides.skills.push(
+                    'assensing',
+                    'astral_combat',
+                    'blade',
+                    'clubs',
+                    'unarmed_combat',
+                    'exotic_range',
+                    'perception',
+                );
                 break;
 
-            case "blackjack":
+            case 'blackjack':
                 overrides.attributes.body = 2;
                 overrides.attributes.agility = 1;
                 overrides.attributes.reaction = 1;
                 overrides.init = 1;
-                overrides.skills.push("assensing", "automatics", "blades", "clubs", "computer", "first_aid", "gymnastics", "intimidation", "locksmith", "longarms", "perception", "pilot_ground_craft", "pistols", "sneaking", "throwing_weapons", "unarmed_combat");
+                overrides.skills.push(
+                    'assensing',
+                    'automatics',
+                    'blades',
+                    'clubs',
+                    'computer',
+                    'first_aid',
+                    'gymnastics',
+                    'intimidation',
+                    'locksmith',
+                    'longarms',
+                    'perception',
+                    'pilot_ground_craft',
+                    'pistols',
+                    'sneaking',
+                    'throwing_weapons',
+                    'unarmed_combat',
+                );
                 break;
 
-            case "boggle":
+            case 'boggle':
                 overrides.attributes.body = -2;
                 overrides.attributes.agility = -1;
                 overrides.attributes.reaction = -1;
                 overrides.attributes.strength = -2;
                 overrides.attributes.willpower = 2;
                 overrides.init = -1;
-                overrides.skills.push("assensing", "astral_combat", "blades", "clubs", "unarmed_combat", "gymnastics", "perception");
+                overrides.skills.push(
+                    'assensing',
+                    'astral_combat',
+                    'blades',
+                    'clubs',
+                    'unarmed_combat',
+                    'gymnastics',
+                    'perception',
+                );
                 break;
 
-            case "bugul":
+            case 'bugul':
                 overrides.attributes.agility = -1;
                 overrides.attributes.reaction = -1;
                 overrides.attributes.strength = -2;
                 overrides.attributes.willpower = 1;
                 overrides.attributes.logic = 2;
-                overrides.skills.push("artisan", "assensing", "astral_combat", "con", "counterspelling", "disenchanting", "gymnastics", "negotiation", "perception", "unarmed_combat");
+                overrides.skills.push(
+                    'artisan',
+                    'assensing',
+                    'astral_combat',
+                    'con',
+                    'counterspelling',
+                    'disenchanting',
+                    'gymnastics',
+                    'negotiation',
+                    'perception',
+                    'unarmed_combat',
+                );
                 break;
 
-            case "chindi":
+            case 'chindi':
                 overrides.attributes.body = 2;
                 overrides.attributes.agility = 1;
                 overrides.attributes.reaction = 2;
                 overrides.attributes.strength = 1;
                 overrides.init = 2;
-                overrides.skills.push("archery", "blades", "clubs", "first_aid", "gymnastics", "intimidation", "perception", "sneaking", "throwing_weapons", "unarmed_combat");
+                overrides.skills.push(
+                    'archery',
+                    'blades',
+                    'clubs',
+                    'first_aid',
+                    'gymnastics',
+                    'intimidation',
+                    'perception',
+                    'sneaking',
+                    'throwing_weapons',
+                    'unarmed_combat',
+                );
                 break;
 
             // HS#119: This spirit types has fixed values that don't use general spirit rules...
-            case "corpselight":
+            case 'corpselight':
                 break;
 
-            case "croki":
+            case 'croki':
                 overrides.attributes.reaction = 2;
                 overrides.attributes.strength = 2;
                 overrides.init = 2;
-                overrides.skills.push("artificing", "assensing", "astral_combat", "gymnastics", "perception", "ritual_spellcasting", "spellcasting");
+                overrides.skills.push(
+                    'artificing',
+                    'assensing',
+                    'astral_combat',
+                    'gymnastics',
+                    'perception',
+                    'ritual_spellcasting',
+                    'spellcasting',
+                );
                 break;
 
-            case "duende":
+            case 'duende':
                 overrides.attributes.reaction = 2;
                 overrides.attributes.strength = 2;
                 overrides.init = 2;
-                overrides.skills.push("assensing", "astral_combat", "con", "gymnastics", "perception");
+                overrides.skills.push('assensing', 'astral_combat', 'con', 'gymnastics', 'perception');
                 break;
 
-            case "ejerian":
-                overrides.skills.push("assensing", "astral_combat", "automatics", "blades", "clubs", "computer", "first_aid", "gymnastics", "intimidation", "locksmith", "longarms", "perception", "pilot_ground_craft", "pistols", "sneaking", "throwing_weapons", "unarmed_combat");
+            case 'ejerian':
+                overrides.skills.push(
+                    'assensing',
+                    'astral_combat',
+                    'automatics',
+                    'blades',
+                    'clubs',
+                    'computer',
+                    'first_aid',
+                    'gymnastics',
+                    'intimidation',
+                    'locksmith',
+                    'longarms',
+                    'perception',
+                    'pilot_ground_craft',
+                    'pistols',
+                    'sneaking',
+                    'throwing_weapons',
+                    'unarmed_combat',
+                );
                 break;
 
-            case "elvar":
+            case 'elvar':
                 overrides.attributes.reaction = 2;
                 overrides.attributes.strength = 2;
                 overrides.init = 2;
-                overrides.skills.push("assensing", "astral_combat", "con", "counterspelling", "disenchanting", "gymnastics", "perception", "spellcasting");
+                overrides.skills.push(
+                    'assensing',
+                    'astral_combat',
+                    'con',
+                    'counterspelling',
+                    'disenchanting',
+                    'gymnastics',
+                    'perception',
+                    'spellcasting',
+                );
                 break;
 
-            case "erinyes":
+            case 'erinyes':
                 overrides.attributes.body = -1;
                 overrides.attributes.agility = 3;
                 overrides.attributes.reaction = 2;
                 overrides.init = 2;
-                overrides.skills.push("assensing", "astral_combat", "flight", "gymnastics", "perception", "sneaking", "unarmed_combat");
+                overrides.skills.push(
+                    'assensing',
+                    'astral_combat',
+                    'flight',
+                    'gymnastics',
+                    'perception',
+                    'sneaking',
+                    'unarmed_combat',
+                );
                 break;
 
-            case "green_man":
+            case 'green_man':
                 overrides.attributes.body = 3;
                 overrides.attributes.agility = -1;
                 overrides.attributes.reaction = 2;
                 overrides.attributes.strength = 4;
                 overrides.init = 2;
-                overrides.skills.push("assensing", "astral_combat", "counterspelling", "gymnastics", "leadership", "perception", "unarmed_combat");
+                overrides.skills.push(
+                    'assensing',
+                    'astral_combat',
+                    'counterspelling',
+                    'gymnastics',
+                    'leadership',
+                    'perception',
+                    'unarmed_combat',
+                );
                 break;
 
-            case "imp":
+            case 'imp':
                 overrides.attributes.reaction = 3;
                 overrides.init = 3;
-                overrides.skills.push("alchemy", "assensing", "astral_combat", "con", "counterspelling", "disenchanting", "gymnastics", "intimidation", "perception", "spellcasting", "unarmed_combat");
+                overrides.skills.push(
+                    'alchemy',
+                    'assensing',
+                    'astral_combat',
+                    'con',
+                    'counterspelling',
+                    'disenchanting',
+                    'gymnastics',
+                    'intimidation',
+                    'perception',
+                    'spellcasting',
+                    'unarmed_combat',
+                );
                 break;
 
-            case "jarl":
+            case 'jarl':
                 overrides.attributes.body = 2;
                 overrides.attributes.agility = -2;
                 overrides.attributes.reaction = 3;
                 overrides.attributes.strength = 2;
                 overrides.init = 4;
-                overrides.skills.push("assensing", "astral_combat", "counterspelling", "gymnastics", "leadership", "perception", "unarmed_combat");
+                overrides.skills.push(
+                    'assensing',
+                    'astral_combat',
+                    'counterspelling',
+                    'gymnastics',
+                    'leadership',
+                    'perception',
+                    'unarmed_combat',
+                );
                 break;
 
-            case "kappa":
+            case 'kappa':
                 overrides.attributes.body = 5;
                 overrides.attributes.reaction = -1;
                 overrides.attributes.strength = 1;
                 overrides.attributes.essence = -2;
                 overrides.init = -1;
-                overrides.skills.push("assensing", "astral_combat", "exotic_range", "gymnastics", "perception", "unarmed_combat");
+                overrides.skills.push(
+                    'assensing',
+                    'astral_combat',
+                    'exotic_range',
+                    'gymnastics',
+                    'perception',
+                    'unarmed_combat',
+                );
                 break;
 
-            case "kokopelli":
+            case 'kokopelli':
                 overrides.attributes.body = -1;
                 overrides.attributes.agility = 2;
                 overrides.attributes.reaction = 2;
                 overrides.init = 2;
-                overrides.skills.push("artisan", "assensing", "astral_combat", "leadership", "perception", "unarmed_combat");
+                overrides.skills.push(
+                    'artisan',
+                    'assensing',
+                    'astral_combat',
+                    'leadership',
+                    'perception',
+                    'unarmed_combat',
+                );
                 break;
 
-            case "morbi":
+            case 'morbi':
                 overrides.attributes.reaction = 1;
                 overrides.attributes.strength = -2;
                 overrides.attributes.intuition = 1;
                 overrides.attributes.charisma = 2;
                 overrides.init = 2;
-                overrides.skills.push("assensing", "astral_combat", "perception", "ritual_spellcasting", "sneaking", "unarmed_combat");
+                overrides.skills.push(
+                    'assensing',
+                    'astral_combat',
+                    'perception',
+                    'ritual_spellcasting',
+                    'sneaking',
+                    'unarmed_combat',
+                );
                 break;
 
-            case "nocnitsa":
+            case 'nocnitsa':
                 overrides.attributes.body = -3;
                 overrides.attributes.agility = 4;
                 overrides.attributes.reaction = 5;
                 overrides.attributes.strength = -2;
                 overrides.attributes.willpower = -1;
                 overrides.init = 5;
-                overrides.skills.push("assensing", "astral_combat", "perception", "sneaking", "unarmed_combat");
+                overrides.skills.push('assensing', 'astral_combat', 'perception', 'sneaking', 'unarmed_combat');
                 break;
 
-            case "phantom":
+            case 'phantom':
                 overrides.attributes.body = 1;
                 overrides.attributes.reaction = 2;
                 overrides.attributes.strength = -2;
                 overrides.init = 2;
-                overrides.skills.push("assensing", "astral_combat", "gymnastics", "perception", "unarmed_combat");
+                overrides.skills.push('assensing', 'astral_combat', 'gymnastics', 'perception', 'unarmed_combat');
                 break;
 
-            case "preta":
+            case 'preta':
                 overrides.attributes.body = -1;
                 overrides.attributes.agility = 1;
                 overrides.attributes.reaction = 2;
                 overrides.attributes.strength = -1;
                 overrides.init = 2;
-                overrides.skills.push("assensing", "astral_combat", "intimidation", "negotiation", "perception", "sneaking", "unarmed_combat");
+                overrides.skills.push(
+                    'assensing',
+                    'astral_combat',
+                    'intimidation',
+                    'negotiation',
+                    'perception',
+                    'sneaking',
+                    'unarmed_combat',
+                );
                 break;
 
-            case "stabber":
+            case 'stabber':
                 overrides.attributes.body = 1;
                 overrides.attributes.agility = 4;
                 overrides.attributes.reaction = 2;
                 overrides.attributes.strength = 4;
                 overrides.init = 2;
-                overrides.skills.push("assensing", "astral_combat", "gymnastics", "perception", "unarmed_combat");
+                overrides.skills.push('assensing', 'astral_combat', 'gymnastics', 'perception', 'unarmed_combat');
                 break;
 
-            case "tungak":
+            case 'tungak':
                 overrides.attributes.body = 1;
                 overrides.attributes.reaction = 2;
                 overrides.attributes.strength = -2;
                 overrides.init = 2;
-                overrides.skills.push("assensing", "astral_combat", "gymnastics", "perception", "unarmed_combat");
+                overrides.skills.push('assensing', 'astral_combat', 'gymnastics', 'perception', 'unarmed_combat');
                 break;
 
-            case "vucub_caquix":
+            case 'vucub_caquix':
                 overrides.attributes.body = 3;
                 overrides.attributes.agility = 4;
                 overrides.attributes.reaction = 4;
@@ -777,20 +1179,20 @@ export class SpiritPrep {
                 overrides.attributes.intuition = 2;
                 overrides.attributes.charisma = 4;
                 overrides.init = 5;
-                overrides.skills.push("assensing", "flight", "perception", "unarmed_combat");
+                overrides.skills.push('assensing', 'flight', 'perception', 'unarmed_combat');
                 break;
 
             // AET#34-37: This spirit types has fixed values that don't use general spirit rules...
-            case "gum_toad":
+            case 'gum_toad':
                 overrides.attributes.body = 7;
                 overrides.attributes.agility = -2;
                 overrides.attributes.strength = 2;
                 overrides.attributes.charisma = 1;
                 overrides.attributes.willpower = -1;
-                overrides.skills.push("assensing", "astral_combat", "perception", "unarmed_combat");
+                overrides.skills.push('assensing', 'astral_combat', 'perception', 'unarmed_combat');
                 break;
 
-            case "crawler":
+            case 'crawler':
                 overrides.attributes.body = 4;
                 overrides.attributes.reaction = 3;
                 overrides.attributes.strength = 6;
@@ -799,47 +1201,84 @@ export class SpiritPrep {
                 overrides.attributes.willpower = -1;
                 overrides.init = 6;
                 overrides.astral_init = 6;
-                overrides.skills.push("assensing", "astral_combat", "perception", "running", "sneaking", "unarmed_combat");
+                overrides.skills.push(
+                    'assensing',
+                    'astral_combat',
+                    'perception',
+                    'running',
+                    'sneaking',
+                    'unarmed_combat',
+                );
                 break;
-                
-            case "ghasts":
+
+            case 'ghasts':
                 overrides.attributes.body = 2;
                 overrides.attributes.reaction = 2;
                 overrides.init = 2;
-                overrides.skills.push("assensing", "astral_combat", "flight", "perception", "spellcasting", "unarmed_combat");
+                overrides.skills.push(
+                    'assensing',
+                    'astral_combat',
+                    'flight',
+                    'perception',
+                    'spellcasting',
+                    'unarmed_combat',
+                );
                 break;
 
-            case "vrygoths":
+            case 'vrygoths':
                 overrides.attributes.body = 4;
                 overrides.attributes.strength = 3;
                 overrides.attributes.logic = 3;
-                overrides.skills.push("assensing", "astral_combat", "flight", "perception", "spellcasting", "unarmed_combat");
+                overrides.skills.push(
+                    'assensing',
+                    'astral_combat',
+                    'flight',
+                    'perception',
+                    'spellcasting',
+                    'unarmed_combat',
+                );
                 break;
 
-            case "gremlin":
+            case 'gremlin':
                 overrides.attributes.reaction = 3;
                 overrides.init = 3;
-                overrides.skills.push("assensing", "astral_combat", "con", "counterspelling", "intimidation", "perception", "spellcasting", "unarmed_combat");
+                overrides.skills.push(
+                    'assensing',
+                    'astral_combat',
+                    'con',
+                    'counterspelling',
+                    'intimidation',
+                    'perception',
+                    'spellcasting',
+                    'unarmed_combat',
+                );
                 break;
 
-            case "anansi":
+            case 'anansi':
                 overrides.attributes.agility = 2;
                 overrides.attributes.reaction = 2;
                 overrides.init = 2;
-                overrides.skills.push("assensing", "astral_combat", "gymnastics", "perception", "sneaking", "unarmed_combat");
+                overrides.skills.push(
+                    'assensing',
+                    'astral_combat',
+                    'gymnastics',
+                    'perception',
+                    'sneaking',
+                    'unarmed_combat',
+                );
                 break;
 
-            case "tsuchigumo_warrior":
+            case 'tsuchigumo_warrior':
                 overrides.attributes.body = 2;
                 overrides.attributes.agility = 2;
                 overrides.attributes.reaction = 1;
                 overrides.attributes.strength = 3;
                 overrides.init = 1;
-                overrides.skills.push("assensing", "astral_combat", "counterspelling", "perception", "unarmed_combat");
+                overrides.skills.push('assensing', 'astral_combat', 'counterspelling', 'perception', 'unarmed_combat');
                 break;
 
             // HT#129
-            case "corps_cadavre":
+            case 'corps_cadavre':
                 overrides.attributes.body = 2;
                 overrides.attributes.agility = -2;
                 overrides.attributes.reaction = -2;
@@ -852,7 +1291,7 @@ export class SpiritPrep {
                 overrides.init_mult = 1;
                 overrides.astral_init_dice = 1;
                 overrides.astral_init_mult = 1;
-                overrides.skills.push("assensing", "astral_combat", "perception", "unarmed_combat");
+                overrides.skills.push('assensing', 'astral_combat', 'perception', 'unarmed_combat');
                 break;
         }
 
@@ -861,10 +1300,10 @@ export class SpiritPrep {
 
     /**
      * The spirits force value is used for the force attribute value.
-     * 
+     *
      * NOTE: This separation is mainly a legacy concern. Attributes are available as testable (and modifiable values)
      *       flat values like force aren't. For this reason the flat value is transformed to an attribute.
-     * 
+     *
      * @param system The spirit system data to prepare
      */
     static prepareAttributesWithForce(system: Actor.SystemOfType<'spirit'>) {

--- a/src/module/actor/prep/functions/SkillsPrep.ts
+++ b/src/module/actor/prep/functions/SkillsPrep.ts
@@ -1,34 +1,41 @@
-import { DataDefaults } from "src/module/data/DataDefaults";
-import { SR5 } from "../../../config";
+import { DataDefaults } from 'src/module/data/DataDefaults';
 import { Helpers } from '../../../helpers';
 import { PartsList } from '../../../parts/PartsList';
 import { SkillFieldType } from 'src/module/types/template/Skills';
+import { ActiveSkillsById } from 'src/module/config/ActiveSkills';
 
 export class SkillsPrep {
     /**
      * Prepare missing skill data as early in during data preparation as possible.
-     * 
+     *
      * template.json is incomplete, so we need to fill in the missing fields.
      * This is mostly a legacy design and should be fixed in the future when DataModel's are used.
-     * 
+     *
      * NOTE: Foundry also calls the prepareData multiple times with incomplete source data, causing some value properties to be missing.
-     * @param system 
+     * @param system
      */
-    static prepareSkillData(system: Actor.SystemOfType<'character' | 'critter' | 'ic' | 'spirit' | 'sprite' | 'vehicle'>) {
+    static prepareSkillData(
+        system: Actor.SystemOfType<'character' | 'critter' | 'ic' | 'spirit' | 'sprite' | 'vehicle'>,
+    ) {
         const { language, active, knowledge } = system.skills;
 
         // Active skills aren't grouped and can be prepared skill by skill.
-        Object.values(active)
-            .forEach((skill) => { DataDefaults.createData('skill_field', skill)} );
+        Object.values(active).forEach((skill) => {
+            DataDefaults.createData('skill_field', skill);
+        });
 
         // Language skills aren't group, but might lack the value property.
         if (language.value)
-            Object.values(language.value).forEach((skill) => { DataDefaults.createData('skill_field', skill)} );
+            Object.values(language.value).forEach((skill) => {
+                DataDefaults.createData('skill_field', skill);
+            });
 
         // Knowledge skills are groupd and might also lack the value property.
         Object.values(knowledge).forEach((group) => {
             if (group.value)
-                Object.values(group.value).forEach((skill) => { DataDefaults.createData('skill_field', skill)} );
+                Object.values(group.value).forEach((skill) => {
+                    DataDefaults.createData('skill_field', skill);
+                });
         });
     }
 
@@ -61,8 +68,10 @@ export class SkillsPrep {
 
         const entries = Object.entries(system.skills.language.value);
         // remove entries which are deleted TODO figure out how to delete these from the data
-        entries.forEach(([key, val]: [string, { _delete?: boolean }]) => val._delete && delete system.skills.language.value[key]);
-        
+        entries.forEach(
+            ([key, val]: [string, { _delete?: boolean }]) => val._delete && delete system.skills.language.value[key],
+        );
+
         for (const skill of Object.values(language.value)) {
             prepareSkill(skill);
             skill.attribute = 'intuition';
@@ -70,8 +79,7 @@ export class SkillsPrep {
 
         // setup knowledge skills
         for (const [, group] of Object.entries(knowledge)) {
-
-            if(!group?.value) {
+            if (!group?.value) {
                 continue;
             }
 
@@ -90,7 +98,7 @@ export class SkillsPrep {
         }
 
         for (const [skillKey, skillValue] of Object.entries(active)) {
-            skillValue.label = SR5.activeSkills[skillKey];
+            skillValue.label = ActiveSkillsById[skillKey].label;
         }
     }
 }

--- a/src/module/config.ts
+++ b/src/module/config.ts
@@ -19,7 +19,7 @@ export const SR5 = {
         modification: 'SR5.Compendiums.Modification',
         weapon: 'SR5.Compendiums.Weapon',
     },
-    
+
     itemTypes: {
         action: 'SR5.ItemTypes.Action',
         adept_power: 'SR5.ItemTypes.AdeptPower',
@@ -44,7 +44,7 @@ export const SR5 = {
         spell: 'SR5.ItemTypes.Spell',
         sprite_power: 'SR5.ItemTypes.SpritePower',
         weapon: 'SR5.ItemTypes.Weapon',
-        call_in_action: 'TYPES.Item.call_in_action'
+        call_in_action: 'TYPES.Item.call_in_action',
     },
 
     // All available attributes. These are available as testable attributes across all actor types.
@@ -88,7 +88,7 @@ export const SR5 = {
         sensor: 'SR5.Vehicle.Stats.Sensor',
         handling: 'SR5.Vehicle.Stats.Handling',
         magic: 'SR5.AttrMagic',
-        initiation: 'SR5.Initiation'
+        initiation: 'SR5.Initiation',
     },
 
     specialTypes: {
@@ -100,7 +100,7 @@ export const SR5 = {
     damageTypes: {
         physical: 'SR5.DmgTypePhysical',
         stun: 'SR5.DmgTypeStun',
-        matrix: 'SR5.DmgTypeMatrix'
+        matrix: 'SR5.DmgTypeMatrix',
     },
 
     weaponRangeCategories: {
@@ -364,8 +364,7 @@ export const SR5 = {
                 long: -1,
                 extreme: -1,
             },
-        }
-
+        },
     },
 
     elementTypes: {
@@ -381,7 +380,7 @@ export const SR5 = {
         detection: 'SR5.Spell.CatDetection',
         health: 'SR5.Spell.CatHealth',
         illusion: 'SR5.Spell.CatIllusion',
-        manipulation: 'SR5.Spell.CatManipulation'
+        manipulation: 'SR5.Spell.CatManipulation',
     },
 
     spellTypes: {
@@ -451,13 +450,13 @@ export const SR5 = {
 
     weaponCliptypes: {
         removable_clip: 'SR5.Weapon.Cliptype.RemovableClip',
-        break_action:'SR5.Weapon.Cliptype.BreakAction',
-        belt_fed:'SR5.Weapon.Cliptype.BeltFed',
-        internal_magazin:'SR5.Weapon.Cliptype.InternalMagazin',
-        muzzle_loader:'SR5.Weapon.Cliptype.MuzzleLoader',
-        cylinder:'SR5.Weapon.Cliptype.Cylinder',
-        drum:'SR5.Weapon.Cliptype.Drum',
-        bow:'SR5.Weapon.Cliptype.Bow',
+        break_action: 'SR5.Weapon.Cliptype.BreakAction',
+        belt_fed: 'SR5.Weapon.Cliptype.BeltFed',
+        internal_magazin: 'SR5.Weapon.Cliptype.InternalMagazin',
+        muzzle_loader: 'SR5.Weapon.Cliptype.MuzzleLoader',
+        cylinder: 'SR5.Weapon.Cliptype.Cylinder',
+        drum: 'SR5.Weapon.Cliptype.Drum',
+        bow: 'SR5.Weapon.Cliptype.Bow',
     },
 
     weaponRanges: {
@@ -470,7 +469,7 @@ export const SR5 = {
     qualityTypes: {
         positive: 'SR5.QualityTypePositive',
         negative: 'SR5.QualityTypeNegative',
-        lifemodule: 'SR5.QualityTypeLifeModule'
+        lifemodule: 'SR5.QualityTypeLifeModule',
     },
 
     adeptPower: {
@@ -503,91 +502,12 @@ export const SR5 = {
         interests: 'SR5.KnowledgeSkillInterests',
     },
 
-    activeSkills: {
-        archery: 'SR5.Skill.Archery',
-        automatics: 'SR5.Skill.Automatics',
-        blades: 'SR5.Skill.Blades',
-        clubs: 'SR5.Skill.Clubs',
-        exotic_melee: 'SR5.Skill.ExoticMelee',
-        exotic_range: 'SR5.Skill.ExoticRange',
-        heavy_weapons: 'SR5.Skill.HeavyWeapons',
-        longarms: 'SR5.Skill.Longarms',
-        pistols: 'SR5.Skill.Pistols',
-        throwing_weapons: 'SR5.Skill.ThrowingWeapons',
-        unarmed_combat: 'SR5.Skill.UnarmedCombat',
-        disguise: 'SR5.Skill.Disguise',
-        diving: 'SR5.Skill.Diving',
-        escape_artist: 'SR5.Skill.EscapeArtist',
-        free_fall: 'SR5.Skill.FreeFall',
-        gymnastics: 'SR5.Skill.Gymnastics',
-        palming: 'SR5.Skill.Palming',
-        perception: 'SR5.Skill.Perception',
-        running: 'SR5.Skill.Running',
-        sneaking: 'SR5.Skill.Sneaking',
-        survival: 'SR5.Skill.Survival',
-        swimming: 'SR5.Skill.Swimming',
-        tracking: 'SR5.Skill.Tracking',
-        con: 'SR5.Skill.Con',
-        etiquette: 'SR5.Skill.Etiquette',
-        impersonation: 'SR5.Skill.Impersonation',
-        instruction: 'SR5.Skill.Instruction',
-        intimidation: 'SR5.Skill.Intimidation',
-        leadership: 'SR5.Skill.Leadership',
-        negotiation: 'SR5.Skill.Negotiation',
-        performance: 'SR5.Skill.Performance',
-        alchemy: 'SR5.Skill.Alchemy',
-        arcana: 'SR5.Skill.Arcana',
-        artificing: 'SR5.Skill.Artificing',
-        assensing: 'SR5.Skill.Assensing',
-        astral_combat: 'SR5.Skill.AstralCombat',
-        banishing: 'SR5.Skill.Banishing',
-        binding: 'SR5.Skill.Binding',
-        counterspelling: 'SR5.Skill.Counterspelling',
-        disenchanting: 'SR5.Skill.Disenchanting',
-        ritual_spellcasting: 'SR5.Skill.RitualSpellcasting',
-        spellcasting: 'SR5.Skill.Spellcasting',
-        summoning: 'SR5.Skill.Summoning',
-        compiling: 'SR5.Skill.Compiling',
-        decompiling: 'SR5.Skill.Decompiling',
-        registering: 'SR5.Skill.Registering',
-        aeronautics_mechanic: 'SR5.Skill.AeronauticsMechanic',
-        automotive_mechanic: 'SR5.Skill.AutomotiveMechanic',
-        industrial_mechanic: 'SR5.Skill.IndustrialMechanic',
-        nautical_mechanic: 'SR5.Skill.NauticalMechanic',
-        animal_handling: 'SR5.Skill.AnimalHandling',
-        armorer: 'SR5.Skill.Armorer',
-        artisan: 'SR5.Skill.Artisan',
-        biotechnology: 'SR5.Skill.Biotechnology',
-        chemistry: 'SR5.Skill.Chemistry',
-        computer: 'SR5.Skill.Computer',
-        cybercombat: 'SR5.Skill.Cybercombat',
-        cybertechnology: 'SR5.Skill.Cybertechnology',
-        demolitions: 'SR5.Skill.Demolitions',
-        electronic_warfare: 'SR5.Skill.ElectronicWarfare',
-        first_aid: 'SR5.Skill.FirstAid',
-        forgery: 'SR5.Skill.Forgery',
-        hacking: 'SR5.Skill.Hacking',
-        hardware: 'SR5.Skill.Hardware',
-        locksmith: 'SR5.Skill.Locksmith',
-        medicine: 'SR5.Skill.Medicine',
-        navigation: 'SR5.Skill.Navigation',
-        software: 'SR5.Skill.Software',
-        gunnery: 'SR5.Skill.Gunnery',
-        pilot_aerospace: 'SR5.Skill.PilotAerospace',
-        pilot_aircraft: 'SR5.Skill.PilotAircraft',
-        pilot_walker: 'SR5.Skill.PilotWalker',
-        pilot_ground_craft: 'SR5.Skill.PilotGroundCraft',
-        pilot_water_craft: 'SR5.Skill.PilotWaterCraft',
-        pilot_exotic_vehicle: 'SR5.Skill.PilotExoticVehicle',
-        flight: 'SR5.Skill.Flight'
-    },
-
     /**
      * Some skills are created on the fly and don't exist on all actors.
      * These values are used for those.
      */
     activeSkillAttribute: {
-        flight: 'agility'
+        flight: 'agility',
     },
 
     actionTypes: {
@@ -603,53 +523,53 @@ export const SR5 = {
         add: '+',
         subtract: '-',
         multiply: '*',
-        divide: '/'
+        divide: '/',
     },
 
     // Map all Shadowrun.ActionCategories to their matching labels.
     // For more information around action categories, see type documentation.
     actionCategories: {
-        'addiction_mental': "SR5.ActionCategory.AddictionMental",
-        'addiction_physical': "SR5.ActionCategory.AddictionPhysical",
-        'addiction': "SR5.ActionCategory.Addiction",
-        'attack_melee': "SR5.ActionCategory.AttackMelee",
-        'attack_ranged': "SR5.ActionCategory.AttackRanged", 
-        'attack_thrown': "SR5.ActionCategory.AttackThrown",
-        'attack': "SR5.ActionCategory.Attack",
-        'brute_force': "SR5.ActionCategory.BruteForce",
-        "climbing": "SR5.ActionCategory.Climbing",
-        'compiling': "SR5.ActionCategory.Compiling",
-        'complex_form': "SR5.ActionCategory.ComplexForm",
-        'defense_suppression': "SR5.ActionCategory.DefenseSuppression",
-        'defense': "SR5.ActionCategory.Defense", 
-        'drain': "SR5.ActionCategory.Drain",
-        'fade': "SR5.ActionCategory.Fade", 
-        'hack_on_the_fly': "SR5.ActionCategory.HackOnTheFly",
-        'magic': "SR5.ActionCategory.Magic",
-        'matrix': 'SR5.ActionCategory.Matrix',
-        'recovery_physical': "SR5.ActionCategory.RecoveryPhysical",
-        'recovery_stun': "SR5.ActionCategory.RecoveryStun",
-        'recovery': "SR5.ActionCategory.Recovery",
-        'resist_disease': "SR5.ActionCategory.ResistDisease",
-        'resist_toxin': "SR5.ActionCategory.ResistToxin",
-        'resist': "SR5.ActionCategory.Resist",
-        'resonance': "SR5.ActionCategory.Resonance",
-        'rigging': "SR5.ActionCategory.Rigging",
-        'social': 'SR5.ActionCategory.Social',
-        'spell_combat': "SR5.ActionCategory.SpellCombat",
-        'spell_detection': "SR5.ActionCategory.SpellDetection",
-        'spell_healing': "SR5.ActionCategory.SpellHealing",
-        'spell_illusion': "SR5.ActionCategory.SpellIllusion", 
-        'spell_manipulation': "SR5.ActionCategory.SpellManipulation",
-        'spell_ritual': "SR5.ActionCategory.SpellRitual",
-        'summoning': "SR5.ActionCategory.Summoning",
+        addiction_mental: 'SR5.ActionCategory.AddictionMental',
+        addiction_physical: 'SR5.ActionCategory.AddictionPhysical',
+        addiction: 'SR5.ActionCategory.Addiction',
+        attack_melee: 'SR5.ActionCategory.AttackMelee',
+        attack_ranged: 'SR5.ActionCategory.AttackRanged',
+        attack_thrown: 'SR5.ActionCategory.AttackThrown',
+        attack: 'SR5.ActionCategory.Attack',
+        brute_force: 'SR5.ActionCategory.BruteForce',
+        climbing: 'SR5.ActionCategory.Climbing',
+        compiling: 'SR5.ActionCategory.Compiling',
+        complex_form: 'SR5.ActionCategory.ComplexForm',
+        defense_suppression: 'SR5.ActionCategory.DefenseSuppression',
+        defense: 'SR5.ActionCategory.Defense',
+        drain: 'SR5.ActionCategory.Drain',
+        fade: 'SR5.ActionCategory.Fade',
+        hack_on_the_fly: 'SR5.ActionCategory.HackOnTheFly',
+        magic: 'SR5.ActionCategory.Magic',
+        matrix: 'SR5.ActionCategory.Matrix',
+        recovery_physical: 'SR5.ActionCategory.RecoveryPhysical',
+        recovery_stun: 'SR5.ActionCategory.RecoveryStun',
+        recovery: 'SR5.ActionCategory.Recovery',
+        resist_disease: 'SR5.ActionCategory.ResistDisease',
+        resist_toxin: 'SR5.ActionCategory.ResistToxin',
+        resist: 'SR5.ActionCategory.Resist',
+        resonance: 'SR5.ActionCategory.Resonance',
+        rigging: 'SR5.ActionCategory.Rigging',
+        social: 'SR5.ActionCategory.Social',
+        spell_combat: 'SR5.ActionCategory.SpellCombat',
+        spell_detection: 'SR5.ActionCategory.SpellDetection',
+        spell_healing: 'SR5.ActionCategory.SpellHealing',
+        spell_illusion: 'SR5.ActionCategory.SpellIllusion',
+        spell_manipulation: 'SR5.ActionCategory.SpellManipulation',
+        spell_ritual: 'SR5.ActionCategory.SpellRitual',
+        summoning: 'SR5.ActionCategory.Summoning',
     },
 
     matrixAttributes: {
         attack: 'SR5.MatrixAttrAttack',
         sleaze: 'SR5.MatrixAttrSleaze',
         data_processing: 'SR5.MatrixAttrDataProc',
-        firewall: 'SR5.MatrixAttrFirewall'
+        firewall: 'SR5.MatrixAttrFirewall',
     },
 
     initiativeCategories: {
@@ -663,7 +583,7 @@ export const SR5 = {
         weapon: 'SR5.Weapon.Weapon',
         armor: 'SR5.Armor',
         vehicle: 'SR5.Vehicle.Vehicle',
-        drone: 'SR5.Vehicle.Drone'
+        drone: 'SR5.Vehicle.Drone',
     },
 
     mountPoints: {
@@ -818,18 +738,18 @@ export const SR5 = {
      * Define here what kind of active test is to be used for the different weapon categories as a main action test.
      */
     weaponCategoryActiveTests: {
-        'range': 'RangedAttackTest',
-        'melee': 'MeleeAttackTest',
-        'thrown': 'ThrownAttackTest'
+        range: 'RangedAttackTest',
+        melee: 'MeleeAttackTest',
+        thrown: 'ThrownAttackTest',
     },
 
     /**
      * When casting tests from these item types, use these tests as active tests
      */
     activeTests: {
-        'spell': 'SpellCastingTest',
-        'ritual': 'RitualSpellcastingTest',
-        'complex_form': 'ComplexFormTest'
+        spell: 'SpellCastingTest',
+        ritual: 'RitualSpellcastingTest',
+        complex_form: 'ComplexFormTest',
     },
 
     /**
@@ -840,9 +760,9 @@ export const SR5 = {
      * }
      */
     opposedTests: {
-        'spell': {
-            'combat': 'CombatSpellDefenseTest'
-        }
+        spell: {
+            combat: 'CombatSpellDefenseTest',
+        },
     },
 
     /**
@@ -852,16 +772,16 @@ export const SR5 = {
      * }
      */
     opposedResistTests: {
-        'spell': {
-            'combat': 'PhysicalResistTest'
-        }
+        spell: {
+            combat: 'PhysicalResistTest',
+        },
     },
 
     /**
      * When a test is cast an active test this defines what tests should follow that tests completion
      */
     followedTests: {
-        'SpellCastingTest': 'DrainTest'
+        SpellCastingTest: 'DrainTest',
     },
 
     // When a firemode with suppression is used, this test should defend against it.
@@ -871,8 +791,8 @@ export const SR5 = {
      * Names of FoundryVTT packs supplied by the system to be used as action sources.
      */
     packNames: {
-        'generalActions': 'general-actions',
-        'matrixActions': 'matrix-actions'
+        generalActions: 'general-actions',
+        matrixActions: 'matrix-actions',
     },
 
     programTypes: {
@@ -940,36 +860,36 @@ export const SR5 = {
         queen: 'SR5.Spirit.Types.Queen',
 
         // Necro types
-        carcass: "SR5.Spirit.Types.Carcass",
-        corpse: "SR5.Spirit.Types.Corpse",
-        rot: "SR5.Spirit.Types.Rot",
-        palefire: "SR5.Spirit.Types.Palefire",
-        detritus: "SR5.Spirit.Types.Detritus",
+        carcass: 'SR5.Spirit.Types.Carcass',
+        corpse: 'SR5.Spirit.Types.Corpse',
+        rot: 'SR5.Spirit.Types.Rot',
+        palefire: 'SR5.Spirit.Types.Palefire',
+        detritus: 'SR5.Spirit.Types.Detritus',
 
         // Howling Shadow spirits
-        anarch: "SR5.Spirit.Types.Anarch",
-        arboreal: "SR5.Spirit.Types.Arboreal",
-        blackjack: "SR5.Spirit.Types.Blackjack",
-        boggle: "SR5.Spirit.Types.Boggle",
-        bugul: "SR5.Spirit.Types.Bugul",
-        chindi: "SR5.Spirit.Types.Chindi",
-        croki: "SR5.Spirit.Types.Croki",
-        duende: "SR5.Spirit.Types.Duende",
-        ejerian: "SR5.Spirit.Types.Ejerian",
-        elvar: "SR5.Spirit.Types.Elvar",
-        erinyes: "SR5.Spirit.Types.Erinyes",
-        green_man: "SR5.Spirit.Types.GreenMan",
-        imp: "SR5.Spirit.Types.Imp",
-        jarl: "SR5.Spirit.Types.Jarl",
-        kappa: "SR5.Spirit.Types.Kappa",
-        kokopelli: "SR5.Spirit.Types.Kokopelli",
-        morbi: "SR5.Spirit.Types.Morbi",
-        nocnitsa: "SR5.Spirit.Types.Nocnitsa",
-        phantom: "SR5.Spirit.Types.Phantom",
-        preta: "SR5.Spirit.Types.Preta",
-        stabber: "SR5.Spirit.Types.Stabber",
-        tungak: "SR5.Spirit.Types.Tungak",
-        vucub_caquix: "SR5.Spirit.Types.VucubCaquix",
+        anarch: 'SR5.Spirit.Types.Anarch',
+        arboreal: 'SR5.Spirit.Types.Arboreal',
+        blackjack: 'SR5.Spirit.Types.Blackjack',
+        boggle: 'SR5.Spirit.Types.Boggle',
+        bugul: 'SR5.Spirit.Types.Bugul',
+        chindi: 'SR5.Spirit.Types.Chindi',
+        croki: 'SR5.Spirit.Types.Croki',
+        duende: 'SR5.Spirit.Types.Duende',
+        ejerian: 'SR5.Spirit.Types.Ejerian',
+        elvar: 'SR5.Spirit.Types.Elvar',
+        erinyes: 'SR5.Spirit.Types.Erinyes',
+        green_man: 'SR5.Spirit.Types.GreenMan',
+        imp: 'SR5.Spirit.Types.Imp',
+        jarl: 'SR5.Spirit.Types.Jarl',
+        kappa: 'SR5.Spirit.Types.Kappa',
+        kokopelli: 'SR5.Spirit.Types.Kokopelli',
+        morbi: 'SR5.Spirit.Types.Morbi',
+        nocnitsa: 'SR5.Spirit.Types.Nocnitsa',
+        phantom: 'SR5.Spirit.Types.Phantom',
+        preta: 'SR5.Spirit.Types.Preta',
+        stabber: 'SR5.Spirit.Types.Stabber',
+        tungak: 'SR5.Spirit.Types.Tungak',
+        vucub_caquix: 'SR5.Spirit.Types.VucubCaquix',
 
         // blood magic spirits
         blood_shade: 'SR5.Spirit.Types.BloodShade',
@@ -993,8 +913,8 @@ export const SR5 = {
      * set in it's system.action_type property.
      */
     callInActorTypes: {
-        'spirit': 'TYPES.Actor.spirit',
-        'sprite': 'TYPES.Actor.sprite'
+        spirit: 'TYPES.Actor.spirit',
+        sprite: 'TYPES.Actor.sprite',
     },
 
     critterPower: {
@@ -1041,7 +961,7 @@ export const SR5 = {
         fault: 'SR5.Sprite.Types.Fault',
         machine: 'SR5.Sprite.Types.Machine',
         companion: 'SR5.Sprite.Types.Companion',
-        generalist:'SR5.Sprite.Types.Generalist',
+        generalist: 'SR5.Sprite.Types.Generalist',
     },
 
     spritePower: {
@@ -1076,7 +996,7 @@ export const SR5 = {
             acceleration: 'SR5.Vehicle.Stats.Acceleration',
             pilot: 'SR5.Vehicle.Stats.Pilot',
             sensor: 'SR5.Vehicle.Stats.Sensor',
-            seats: 'SR5.Vehicle.Stats.Seats'
+            seats: 'SR5.Vehicle.Stats.Seats',
         },
         control_modes: {
             manual: 'SR5.Vehicle.ControlModes.Manual',
@@ -1092,27 +1012,27 @@ export const SR5 = {
 
     ic: {
         types: {
-            acid: "SR5.IC.Types.Acid",
-            binder: "SR5.IC.Types.Binder",
-            black_ic: "SR5.IC.Types.BlackIC",
-            blaster: "SR5.IC.Types.Blaster",
-            bloodhound: "SR5.IC.Types.Bloodhound",
-            blue_goo: "SR5.IC.Types.BlueGoo",
-            catapult: "SR5.IC.Types.Catapult",
-            crash: "SR5.IC.Types.Crash",
-            flicker: "SR5.IC.Types.Flicker",
-            jammer: "SR5.IC.Types.Jammer",
-            killer: "SR5.IC.Types.Killer",
-            marker: "SR5.IC.Types.Marker",
-            patrol: "SR5.IC.Types.Patrol",
-            probe: "SR5.IC.Types.Probe",
-            scramble: "SR5.IC.Types.Scramble",
-            shocker: "SR5.IC.Types.Shocker",
-            sleuther: "SR5.IC.Types.Sleuther",
-            sparky: "SR5.IC.Types.Sparky",
-            tar_baby: "SR5.IC.Types.TarBaby",
-            track: "SR5.IC.Types.Track"
-        }
+            acid: 'SR5.IC.Types.Acid',
+            binder: 'SR5.IC.Types.Binder',
+            black_ic: 'SR5.IC.Types.BlackIC',
+            blaster: 'SR5.IC.Types.Blaster',
+            bloodhound: 'SR5.IC.Types.Bloodhound',
+            blue_goo: 'SR5.IC.Types.BlueGoo',
+            catapult: 'SR5.IC.Types.Catapult',
+            crash: 'SR5.IC.Types.Crash',
+            flicker: 'SR5.IC.Types.Flicker',
+            jammer: 'SR5.IC.Types.Jammer',
+            killer: 'SR5.IC.Types.Killer',
+            marker: 'SR5.IC.Types.Marker',
+            patrol: 'SR5.IC.Types.Patrol',
+            probe: 'SR5.IC.Types.Probe',
+            scramble: 'SR5.IC.Types.Scramble',
+            shocker: 'SR5.IC.Types.Shocker',
+            sleuther: 'SR5.IC.Types.Sleuther',
+            sparky: 'SR5.IC.Types.Sparky',
+            tar_baby: 'SR5.IC.Types.TarBaby',
+            track: 'SR5.IC.Types.Track',
+        },
     },
 
     character: {
@@ -1135,18 +1055,13 @@ export const SR5 = {
      * NOTE: This list is also used for sorting order of ranged weapon mode.
      *       Alter it with care.
      */
-    rangeWeaponMode: [
-        'single_shot',
-        'semi_auto',
-        'burst_fire',
-        'full_auto'
-    ],
+    rangeWeaponMode: ['single_shot', 'semi_auto', 'burst_fire', 'full_auto'],
 
     rangeWeaponModeLabel: {
-        'single_shot': 'SR5.Weapon.Mode.SingleShot',
-        'semi_auto': 'SR5.Weapon.Mode.SemiAuto',
-        'burst_file': 'SR5.Weapon.Mode.BurstFire',
-        'full_auto': 'SR5.Weapon.Mode.FullAuto'
+        single_shot: 'SR5.Weapon.Mode.SingleShot',
+        semi_auto: 'SR5.Weapon.Mode.SemiAuto',
+        burst_file: 'SR5.Weapon.Mode.BurstFire',
+        full_auto: 'SR5.Weapon.Mode.FullAuto',
     },
 
     /**
@@ -1156,79 +1071,79 @@ export const SR5 = {
      * ranged weapon mode.
      */
     fireModes: [
-    {
-        label: "SR5.Weapon.Mode.SingleShot",
-        value: 1,
-        recoil: false,
-        defense: 0,
-        suppression: false,
-        action: 'simple',
-        mode: 'single_shot'
-    },
-    {
-        label: "SR5.Weapon.Mode.SemiAutoShort",
-        value: 1,
-        recoil: true,
-        defense: 0,
-        suppression: false,
-        action: 'simple',
-        mode: 'semi_auto'
-    },
-    {
-        label: "SR5.Weapon.Mode.SemiAutoBurst",
-        value: 3,
-        recoil: true,
-        defense: -2,
-        suppression: false,
-        action: 'complex',
-        mode: 'semi_auto'
-    },
+        {
+            label: 'SR5.Weapon.Mode.SingleShot',
+            value: 1,
+            recoil: false,
+            defense: 0,
+            suppression: false,
+            action: 'simple',
+            mode: 'single_shot',
+        },
+        {
+            label: 'SR5.Weapon.Mode.SemiAutoShort',
+            value: 1,
+            recoil: true,
+            defense: 0,
+            suppression: false,
+            action: 'simple',
+            mode: 'semi_auto',
+        },
+        {
+            label: 'SR5.Weapon.Mode.SemiAutoBurst',
+            value: 3,
+            recoil: true,
+            defense: -2,
+            suppression: false,
+            action: 'complex',
+            mode: 'semi_auto',
+        },
 
-    {
-        label: "SR5.Weapon.Mode.BurstFire",
-        value: 3,
-        recoil: true,
-        defense: -2,
-        suppression: false,
-        action: 'simple',
-        mode: 'burst_fire'
-    },
-    {
-        label: "SR5.Weapon.Mode.BurstFireLong",
-        value: 6,
-        recoil: true,
-        defense: -5,
-        suppression: false,
-        action: 'complex',
-        mode: 'burst_fire',
-    },
-    {
-        label: "SR5.Weapon.Mode.FullAutoShort",
-        value: 6,
-        recoil: true,
-        defense: -5,
-        suppression: false,
-        action: 'simple',
-        mode: 'full_auto'
-    },
-    {
-        label: 'SR5.Weapon.Mode.FullAutoLong',
-        value: 10,
-        recoil: true,
-        defense: -9,
-        suppression: false,
-        action: 'complex',
-        mode: 'full_auto'
-    },
-    {
-        label: 'SR5.Suppressing',
-        value: 20,
-        recoil: false,
-        defense: 0,
-        suppression: true,
-        action: 'complex',
-        mode: 'full_auto'
-    }
+        {
+            label: 'SR5.Weapon.Mode.BurstFire',
+            value: 3,
+            recoil: true,
+            defense: -2,
+            suppression: false,
+            action: 'simple',
+            mode: 'burst_fire',
+        },
+        {
+            label: 'SR5.Weapon.Mode.BurstFireLong',
+            value: 6,
+            recoil: true,
+            defense: -5,
+            suppression: false,
+            action: 'complex',
+            mode: 'burst_fire',
+        },
+        {
+            label: 'SR5.Weapon.Mode.FullAutoShort',
+            value: 6,
+            recoil: true,
+            defense: -5,
+            suppression: false,
+            action: 'simple',
+            mode: 'full_auto',
+        },
+        {
+            label: 'SR5.Weapon.Mode.FullAutoLong',
+            value: 10,
+            recoil: true,
+            defense: -9,
+            suppression: false,
+            action: 'complex',
+            mode: 'full_auto',
+        },
+        {
+            label: 'SR5.Suppressing',
+            value: 20,
+            recoil: false,
+            defense: 0,
+            suppression: true,
+            action: 'complex',
+            mode: 'full_auto',
+        },
     ],
 
     /**
@@ -1237,18 +1152,18 @@ export const SR5 = {
      * actor is the default Foundry apply to type of ActiveEffects and will be affect actor data.
      */
     effectApplyTo: {
-        'actor': 'SR5.FOUNDRY.Actor',
+        actor: 'SR5.FOUNDRY.Actor',
         // 'item': 'SR5.FOUNDRY.Item', // Disabled, as systems nested item approach brings issues.
-        'targeted_actor': 'SR5.ActiveEffect.ApplyTos.TargetedActor',
-        'test_all': 'SR5.Test',
-        'test_item': 'SR5.ActiveEffect.ApplyTos.TestItem',
-        'modifier': 'SR5.Modifier'
+        targeted_actor: 'SR5.ActiveEffect.ApplyTos.TargetedActor',
+        test_all: 'SR5.Test',
+        test_item: 'SR5.ActiveEffect.ApplyTos.TestItem',
+        modifier: 'SR5.Modifier',
     },
 
     itemSubTypeIconOverrides: {
         action: {},
         adept_power: {
-            'adept-spell': 'spell/spell'
+            'adept-spell': 'spell/spell',
         },
         ammo: {
             'ammo': '',
@@ -1260,14 +1175,14 @@ export const SR5 = {
             'minigrenade': '',
             'missile': '',
             'rocket': '',
-            'torpedo-grenade': ''
+            'torpedo-grenade': '',
         },
         armor: {
             'armor': '',
             'cloaks': '',
             'clothing': '',
             'high-fashion-armor-clothing': '',
-            'specialty-armor': ''
+            'specialty-armor': '',
         },
         bioware: {
             'basic': 'bioware/bioware',
@@ -1285,7 +1200,7 @@ export const SR5 = {
             'phenotype-adjustment': 'bioware/biosculpting',
             'symbionts': 'bioware/cultured',
             'transgenic-alteration': 'bioware/transgenic-alteration',
-            'transgenics': ''
+            'transgenics': '',
         },
         character: {
             'dracoforms': 'critter/dracoforms',
@@ -1302,8 +1217,8 @@ export const SR5 = {
         complex_form: {},
         contact: {},
         critter_power: {
-            'mana': '',
-            'physical': 'critter_power/critter_power'
+            mana: '',
+            physical: 'critter_power/critter_power',
         },
         cyberware: {
             'auto-injector-mods': '',
@@ -1321,12 +1236,12 @@ export const SR5 = {
             'headware': 'cyberware/cyberware',
             'nanocybernetics': 'cyberware/hard-nanoware',
             'soft-nanoware': 'cyberware/hard-nanoware',
-            'special-biodrone-cyberware': ''
+            'special-biodrone-cyberware': '',
         },
         device: {
-            'commlink': 'device',
-            'cyberdeck': '',
-            'rcc': ''
+            commlink: 'device',
+            cyberdeck: '',
+            rcc: '',
         },
         echo: {},
         equipment: {
@@ -1395,36 +1310,36 @@ export const SR5 = {
             'tools-of-the-trade': '',
             'toxins': '',
             'vision-devices': '',
-            'vision-enhancements': ''
+            'vision-enhancements': '',
         },
         host: {},
         lifestyle: {},
         metamagic: {},
         modification: {
-            'barrel': '',
-            'other': '',
-            'side': '',
-            'stock': '',
-            'top': '',
-            'under': 'modification/modification'
+            barrel: '',
+            other: '',
+            side: '',
+            stock: '',
+            top: '',
+            under: 'modification/modification',
         },
-        program:        {
-            'common_program': '',
-            'hacking_program': ''
+        program: {
+            common_program: '',
+            hacking_program: '',
         },
         quality: {
-            'negative': '',
-            'positive': ''
+            negative: '',
+            positive: '',
         },
         ritual: {},
         sin: {},
         spell: {
-            'combat': '',
-            'detection': '',
-            'enchantments': '',
-            'health': '',
-            'illusion': '',
-            'manipulation': ''
+            combat: '',
+            detection: '',
+            enchantments: '',
+            health: '',
+            illusion: '',
+            manipulation: '',
         },
         spirit: {
             'extraplanar-travelers': 'critter/extraplanar-travelers',
@@ -1506,7 +1421,7 @@ export const SR5 = {
             'tasers': '',
             'torpedo-grenade': 'ammo/torpedo-grenade',
             'unarmed': '',
-            'underbarrel-weapons': 'modification/modification'
-        }
-    }
+            'underbarrel-weapons': 'modification/modification',
+        },
+    },
 } as const;

--- a/src/module/config/ActiveSkills.ts
+++ b/src/module/config/ActiveSkills.ts
@@ -1,0 +1,1100 @@
+/*
+ * ActiveSkills.ts
+ * => Contains Shadowrun 5th Edition raw data for ActiveSkills
+ * to interface with the rest of the app
+ */
+
+// to be expanded, internal type to hide certain content
+// not only skills, added it here atm
+// TODO: Once used, move to its own file
+export interface Requirement {
+    isInverted?: boolean;
+    combine?: 'every' | 'some';
+    chainMode?: 'and' | 'or';
+    characterFlags?: string[];
+    attributes?: Record<string, number>;
+    activeSkills?: Record<string, number>;
+}
+
+// mapping of skill data, so we do not need to fracture all
+// skills across 3+ files
+export interface ActiveSkillDefinition {
+    id: string;
+    label: string;
+    skillGroupLabel: string;
+    specializations: string[];
+    linkedAttribute: string;
+    flags: {
+        canDefault: boolean;
+        isSpecific: boolean;
+    };
+    category: string;
+    requires: Requirement[];
+}
+
+// TODO: Change categories to labels for cosmetic purposes?
+export const ActiveSkillData: ActiveSkillDefinition[] = [
+    {
+        id: 'archery',
+        label: 'SR5.Skill.Archery',
+        skillGroupLabel: '',
+        specializations: ['Bow', 'Crossbow', 'Non-Standard Ammunition', 'Slingshot'],
+        linkedAttribute: 'agility',
+        flags: {
+            canDefault: true,
+            isSpecific: false,
+        },
+        category: 'Combat',
+        requires: [],
+    },
+    {
+        id: 'automatics',
+        label: 'SR5.Skill.Automatics',
+        skillGroupLabel: 'SR5.SkillGroup.Firearms',
+        specializations: ['Assault Rifles', 'Cyber-Implant', 'Machine Pistols', 'Submachine Guns'],
+        linkedAttribute: 'agility',
+        flags: {
+            canDefault: true,
+            isSpecific: false,
+        },
+        category: 'Combat',
+        requires: [],
+    },
+    {
+        id: 'blades',
+        label: 'SR5.Skill.Blades',
+        skillGroupLabel: 'SR5.SkillGroup.CloseCombat',
+        specializations: ['Axes', 'Knives', 'Swords', 'Parrying'],
+        linkedAttribute: 'agility',
+        flags: {
+            canDefault: true,
+            isSpecific: false,
+        },
+        category: 'Combat',
+        requires: [],
+    },
+    {
+        id: 'clubs',
+        label: 'SR5.Skill.Clubs',
+        skillGroupLabel: 'SR5.SkillGroup.CloseCombat',
+        specializations: ['Batons', 'Hammers', 'Saps', 'Staves', 'Parrying'],
+        linkedAttribute: 'agility',
+        flags: {
+            canDefault: true,
+            isSpecific: false,
+        },
+        category: 'Combat',
+        requires: [],
+    },
+    {
+        id: 'exotic_melee',
+        label: 'SR5.Skill.ExoticMelee',
+        skillGroupLabel: '',
+        specializations: [],
+        linkedAttribute: 'agility',
+        flags: {
+            canDefault: false,
+            isSpecific: true,
+        },
+        category: 'Combat',
+        requires: [],
+    },
+    {
+        id: 'exotic_range',
+        label: 'SR5.Skill.ExoticRange',
+        skillGroupLabel: '',
+        specializations: [],
+        linkedAttribute: 'agility',
+        flags: {
+            canDefault: false,
+            isSpecific: true,
+        },
+        category: 'Combat',
+        requires: [],
+    },
+    {
+        id: 'heavy_weapons',
+        label: 'SR5.Skill.HeavyWeapons',
+        skillGroupLabel: '',
+        specializations: [
+            'Assault Cannons',
+            'Grenade Launchers',
+            'Guided Missiles',
+            'Machine Guns',
+            'Rocket Launchers',
+        ],
+        linkedAttribute: 'agility',
+        flags: {
+            canDefault: true,
+            isSpecific: false,
+        },
+        category: 'Combat',
+        requires: [],
+    },
+    {
+        id: 'longarms',
+        label: 'SR5.Skill.Longarms',
+        skillGroupLabel: 'SR5.SkillGroup.Firearms',
+        specializations: ['Extended-Range Shots', 'Long-Range Shots', 'Shotguns', 'Sniper Rifles'],
+        linkedAttribute: 'agility',
+        flags: {
+            canDefault: true,
+            isSpecific: false,
+        },
+        category: 'Combat',
+        requires: [],
+    },
+    {
+        id: 'pistols',
+        label: 'SR5.Skill.Pistols',
+        skillGroupLabel: 'SR5.SkillGroup.Firearms',
+        specializations: ['Holdouts', 'Revolvers', 'Semi-Automatics', 'Tasers'],
+        linkedAttribute: 'agility',
+        flags: {
+            canDefault: true,
+            isSpecific: false,
+        },
+        category: 'Combat',
+        requires: [],
+    },
+    {
+        id: 'throwing_weapons',
+        label: 'SR5.Skill.ThrowingWeapons',
+        skillGroupLabel: '',
+        specializations: ['Aerodynamic', 'Blades', 'Non-Aerodynamic'],
+        linkedAttribute: 'agility',
+        flags: {
+            canDefault: true,
+            isSpecific: false,
+        },
+        category: 'Combat',
+        requires: [],
+    },
+    {
+        id: 'unarmed_combat',
+        label: 'SR5.Skill.UnarmedCombat',
+        skillGroupLabel: 'SR5.SkillGroup.CloseCombat',
+        specializations: ['Blocking', 'Cyber-Implants', 'Subduing Combat', 'Specific Martial Art'],
+        linkedAttribute: 'agility',
+        flags: {
+            canDefault: true,
+            isSpecific: false,
+        },
+        category: 'Combat',
+        requires: [],
+    },
+    {
+        id: 'disguise',
+        label: 'SR5.Skill.Disguise',
+        skillGroupLabel: 'SR5.SkillGroup.Stealth',
+        specializations: ['Camouflage', 'Cosmetic', 'Theatrical', 'Trideo & Video'],
+        linkedAttribute: 'intuition',
+        flags: {
+            canDefault: true,
+            isSpecific: false,
+        },
+        category: 'Physical',
+        requires: [],
+    },
+    {
+        id: 'diving',
+        label: 'SR5.Skill.Diving',
+        skillGroupLabel: '',
+        specializations: ['By Breathing Apparatus', 'By Condition', 'Controlled Hyperventilation'],
+        linkedAttribute: 'body',
+        flags: {
+            canDefault: true,
+            isSpecific: false,
+        },
+        category: 'Physical',
+        requires: [],
+    },
+    {
+        id: 'escape_artist',
+        label: 'SR5.Skill.EscapeArtist',
+        skillGroupLabel: '',
+        specializations: ['By Restraint', 'Contortionism'],
+        linkedAttribute: 'agility',
+        flags: {
+            canDefault: true,
+            isSpecific: false,
+        },
+        category: 'Physical',
+        requires: [],
+    },
+    {
+        id: 'free_fall',
+        label: 'SR5.Skill.FreeFall',
+        skillGroupLabel: '',
+        specializations: [
+            'BASE Jumping',
+            'Break-Fall',
+            'Bungee',
+            'HALO',
+            'Low Altitude',
+            'Parachute',
+            'Static Line',
+            'Wingsuit',
+            'Zipline',
+        ],
+        linkedAttribute: 'body',
+        flags: {
+            canDefault: true,
+            isSpecific: false,
+        },
+        category: 'Physical',
+        requires: [],
+    },
+    {
+        id: 'gymnastics',
+        label: 'SR5.Skill.Gymnastics',
+        skillGroupLabel: 'SR5.SkillGroup.Athletics',
+        specializations: ['Balance', 'Climbing', 'Dance', 'Leaping', 'Parkour', 'Rolling'],
+        linkedAttribute: 'agility',
+        flags: {
+            canDefault: true,
+            isSpecific: false,
+        },
+        category: 'Physical',
+        requires: [],
+    },
+    {
+        id: 'palming',
+        label: 'SR5.Skill.Palming',
+        skillGroupLabel: 'SR5.SkillGroup.Stealth',
+        specializations: ['Legerdemain', 'Pickpocket', 'Pilfering'],
+        linkedAttribute: 'agility',
+        flags: {
+            canDefault: false,
+            isSpecific: false,
+        },
+        category: 'Physical',
+        requires: [],
+    },
+    {
+        id: 'perception',
+        label: 'SR5.Skill.Perception',
+        skillGroupLabel: '',
+        specializations: ['Hearing', 'Scent', 'Searching', 'Taste', 'Touch', 'Visual'],
+        linkedAttribute: 'intuition',
+        flags: {
+            canDefault: true,
+            isSpecific: false,
+        },
+        category: 'Physical',
+        requires: [],
+    },
+    {
+        id: 'running',
+        label: 'SR5.Skill.Running',
+        skillGroupLabel: 'SR5.SkillGroup.Athletics',
+        specializations: ['Distance', 'Sprinting', 'By Terrain'],
+        linkedAttribute: 'strength',
+        flags: {
+            canDefault: true,
+            isSpecific: false,
+        },
+        category: 'Physical',
+        requires: [],
+    },
+    {
+        id: 'sneaking',
+        label: 'SR5.Skill.Sneaking',
+        skillGroupLabel: 'SR5.SkillGroup.Stealth',
+        specializations: ['By Terrain'],
+        linkedAttribute: 'agility',
+        flags: {
+            canDefault: true,
+            isSpecific: false,
+        },
+        category: 'Physical',
+        requires: [],
+    },
+    {
+        id: 'survival',
+        label: 'SR5.Skill.Survival',
+        skillGroupLabel: 'SR5.SkillGroup.Outdoors',
+        specializations: ['By Terrain'],
+        linkedAttribute: 'willpower',
+        flags: {
+            canDefault: true,
+            isSpecific: false,
+        },
+        category: 'Physical',
+        requires: [],
+    },
+    {
+        id: 'swimming',
+        label: 'SR5.Skill.Swimming',
+        skillGroupLabel: 'SR5.SkillGroup.Athletics',
+        specializations: ['Dash', 'Long Distance'],
+        linkedAttribute: 'strength',
+        flags: {
+            canDefault: true,
+            isSpecific: false,
+        },
+        category: 'Physical',
+        requires: [],
+    },
+    {
+        id: 'tracking',
+        label: 'SR5.Skill.Tracking',
+        skillGroupLabel: 'SR5.SkillGroup.Outdoors',
+        specializations: ['By Terrain'],
+        linkedAttribute: 'intuition',
+        flags: {
+            canDefault: true,
+            isSpecific: false,
+        },
+        category: 'Physical',
+        requires: [],
+    },
+    {
+        id: 'con',
+        label: 'SR5.Skill.Con',
+        skillGroupLabel: 'SR5.SkillGroup.Acting',
+        specializations: ['Fast Talking', 'Seduction'],
+        linkedAttribute: 'charisma',
+        flags: {
+            canDefault: true,
+            isSpecific: false,
+        },
+        category: 'Social',
+        requires: [],
+    },
+    {
+        id: 'etiquette',
+        label: 'SR5.Skill.Etiquette',
+        skillGroupLabel: 'SR5.SkillGroup.Influence',
+        specializations: ['By Culture', 'By Subculture'],
+        linkedAttribute: 'charisma',
+        flags: {
+            canDefault: true,
+            isSpecific: false,
+        },
+        category: 'Social',
+        requires: [],
+    },
+    {
+        id: 'impersonation',
+        label: 'SR5.Skill.Impersonation',
+        skillGroupLabel: 'SR5.SkillGroup.Acting',
+        specializations: ['By Metahuman Type'],
+        linkedAttribute: 'charisma',
+        flags: {
+            canDefault: true,
+            isSpecific: false,
+        },
+        category: 'Social',
+        requires: [],
+    },
+    {
+        id: 'instruction',
+        label: 'SR5.Skill.Instruction',
+        skillGroupLabel: '',
+        specializations: ['By Active Skill Category', 'By Knowledge Skill Category'],
+        linkedAttribute: 'charisma',
+        flags: {
+            canDefault: true,
+            isSpecific: false,
+        },
+        category: 'Social',
+        requires: [],
+    },
+    {
+        id: 'intimidation',
+        label: 'SR5.Skill.Intimidation',
+        skillGroupLabel: '',
+        specializations: ['Interrogation', 'Mental', 'Physical', 'Torture'],
+        linkedAttribute: 'charisma',
+        flags: {
+            canDefault: true,
+            isSpecific: false,
+        },
+        category: 'Social',
+        requires: [],
+    },
+    {
+        id: 'leadership',
+        label: 'SR5.Skill.Leadership',
+        skillGroupLabel: 'SR5.SkillGroup.Influence',
+        specializations: ['Command', 'Direct', 'Inspire', 'Rally'],
+        linkedAttribute: 'charisma',
+        flags: {
+            canDefault: true,
+            isSpecific: false,
+        },
+        category: 'Social',
+        requires: [],
+    },
+    {
+        id: 'negotiation',
+        label: 'SR5.Skill.Negotiation',
+        skillGroupLabel: 'SR5.SkillGroup.Influence',
+        specializations: ['Bargaining', 'Contracts', 'Diplomacy'],
+        linkedAttribute: 'charisma',
+        flags: {
+            canDefault: true,
+            isSpecific: false,
+        },
+        category: 'Social',
+        requires: [],
+    },
+    {
+        id: 'performance',
+        label: 'SR5.Skill.Performance',
+        skillGroupLabel: 'SR5.SkillGroup.Acting',
+        specializations: ['By Performance Art'],
+        linkedAttribute: 'charisma',
+        flags: {
+            canDefault: true,
+            isSpecific: false,
+        },
+        category: 'Social',
+        requires: [],
+    },
+    {
+        id: 'alchemy',
+        label: 'SR5.Skill.Alchemy',
+        skillGroupLabel: 'SR5.SkillGroup.Enchanting',
+        specializations: ['By Trigger', 'By Spell Type'],
+        linkedAttribute: 'magic',
+        flags: {
+            canDefault: false,
+            isSpecific: false,
+        },
+        category: 'Magic',
+        requires: [{ characterFlags: ['can-enchant'] }],
+    },
+    {
+        id: 'arcana',
+        label: 'SR5.Skill.Arcana',
+        skillGroupLabel: '',
+        specializations: ['Spell Design', 'Focus Design', 'Spirit Formula'],
+        linkedAttribute: 'logic',
+        flags: {
+            canDefault: false,
+            isSpecific: false,
+        },
+        category: 'Magic',
+        // TODO?: keep or remove the requirement
+        requires: [{ attributes: { magic: 1 } }],
+    },
+    {
+        id: 'artificing',
+        label: 'SR5.Skill.Artificing',
+        skillGroupLabel: 'SR5.SkillGroup.Enchanting',
+        specializations: ['Focus Analysis', 'By Focus Type'],
+        linkedAttribute: 'magic',
+        flags: {
+            canDefault: false,
+            isSpecific: false,
+        },
+        category: 'Magic',
+        requires: [{ characterFlags: ['can-enchant'] }],
+    },
+    {
+        id: 'assensing',
+        label: 'SR5.Skill.Assensing',
+        skillGroupLabel: '',
+        specializations: ['Aura Reading', 'Astral Signatures', 'By Aura Type'],
+        linkedAttribute: 'intuition',
+        flags: {
+            canDefault: false,
+            isSpecific: false,
+        },
+        category: 'Magic',
+        requires: [{ characterFlags: ['can-astrally-percieve'] }],
+    },
+    {
+        id: 'astral_combat',
+        label: 'SR5.Skill.AstralCombat',
+        skillGroupLabel: '',
+        specializations: ['By Weapon Focus Type', 'By Opponents'],
+        linkedAttribute: 'willpower',
+        flags: {
+            canDefault: false,
+            isSpecific: false,
+        },
+        category: 'Magic',
+        requires: [{ characterFlags: ['can-astrally-percieve'] }],
+    },
+    {
+        id: 'banishing',
+        label: 'SR5.Skill.Banishing',
+        skillGroupLabel: 'SR5.SkillGroup.Conjuring',
+        specializations: ['By Spirit Type'],
+        linkedAttribute: 'magic',
+        flags: {
+            canDefault: false,
+            isSpecific: false,
+        },
+        category: 'Magic',
+        requires: [{ characterFlags: ['can-summon'] }],
+    },
+    {
+        id: 'binding',
+        label: 'SR5.Skill.Binding',
+        skillGroupLabel: 'SR5.SkillGroup.Conjuring',
+        specializations: ['By Spirit Type'],
+        linkedAttribute: 'magic',
+        flags: {
+            canDefault: false,
+            isSpecific: false,
+        },
+        category: 'Magic',
+        requires: [{ characterFlags: ['can-summon'] }],
+    },
+    {
+        id: 'counterspelling',
+        label: 'SR5.Skill.Counterspelling',
+        skillGroupLabel: 'SR5.SkillGroup.Sorcery',
+        specializations: ['By Spell Type'],
+        linkedAttribute: 'magic',
+        flags: {
+            canDefault: false,
+            isSpecific: false,
+        },
+        category: 'Magic',
+        requires: [{ characterFlags: ['can-spellcast'] }],
+    },
+    {
+        id: 'disenchanting',
+        label: 'SR5.Skill.Disenchanting',
+        skillGroupLabel: 'SR5.SkillGroup.Enchanting',
+        specializations: ['By Artifact Type'],
+        linkedAttribute: 'magic',
+        flags: {
+            canDefault: false,
+            isSpecific: false,
+        },
+        category: 'Magic',
+        requires: [{ characterFlags: ['can-enchant'] }],
+    },
+    {
+        id: 'ritual_spellcasting',
+        label: 'SR5.Skill.RitualSpellcasting',
+        skillGroupLabel: 'SR5.SkillGroup.Sorcery',
+        specializations: ['By Magic Keyword'],
+        linkedAttribute: 'magic',
+        flags: {
+            canDefault: false,
+            isSpecific: false,
+        },
+        category: 'Magic',
+        requires: [{ characterFlags: ['can-spellcast'] }],
+    },
+    {
+        id: 'spellcasting',
+        label: 'SR5.Skill.Spellcasting',
+        skillGroupLabel: 'SR5.SkillGroup.Sorcery',
+        specializations: ['By Spell Type'],
+        linkedAttribute: 'magic',
+        flags: {
+            canDefault: false,
+            isSpecific: false,
+        },
+        category: 'Magic',
+        requires: [{ characterFlags: ['can-spellcast'] }],
+    },
+    {
+        id: 'summoning',
+        label: 'SR5.Skill.Summoning',
+        skillGroupLabel: 'SR5.SkillGroup.Conjuring',
+        specializations: ['By Spirit Type'],
+        linkedAttribute: 'magic',
+        flags: {
+            canDefault: false,
+            isSpecific: false,
+        },
+        category: 'Magic',
+        requires: [{ characterFlags: ['can-summon'] }],
+    },
+    {
+        id: 'compiling',
+        label: 'SR5.Skill.Compiling',
+        skillGroupLabel: 'SR5.SkillGroup.Tasking',
+        specializations: ['By sprite type'],
+        linkedAttribute: 'resonance',
+        flags: {
+            canDefault: false,
+            isSpecific: false,
+        },
+        category: 'Resonance',
+        requires: [{ attributes: { resonance: 1 } }],
+    },
+    {
+        id: 'decompiling',
+        label: 'SR5.Skill.Decompiling',
+        skillGroupLabel: 'SR5.SkillGroup.Tasking',
+        specializations: ['By sprite type'],
+        linkedAttribute: 'resonance',
+        flags: {
+            canDefault: false,
+            isSpecific: false,
+        },
+        category: 'Resonance',
+        requires: [{ attributes: { resonance: 1 } }],
+    },
+    {
+        id: 'registering',
+        label: 'SR5.Skill.Registering',
+        skillGroupLabel: 'SR5.SkillGroup.Tasking',
+        specializations: ['By sprite type'],
+        linkedAttribute: 'resonance',
+        flags: {
+            canDefault: false,
+            isSpecific: false,
+        },
+        category: 'Resonance',
+        requires: [{ attributes: { resonance: 1 } }],
+    },
+    {
+        id: 'aeronautics_mechanic',
+        label: 'SR5.Skill.AeronauticsMechanic',
+        skillGroupLabel: 'SR5.SkillGroup.Engineering',
+        specializations: ['Aerospace', 'Fixed Wing', 'LTA', 'Rotary Wing', 'Tilt Wing', 'Vector Thrust'],
+        linkedAttribute: 'logic',
+        flags: {
+            canDefault: false,
+            isSpecific: false,
+        },
+        category: 'Technical',
+        requires: [],
+    },
+    {
+        id: 'animal_handling',
+        label: 'SR5.Skill.AnimalHandling',
+        skillGroupLabel: '',
+        specializations: ['By animal', 'Herding', 'Riding', 'Training'],
+        linkedAttribute: 'charisma',
+        flags: {
+            canDefault: true,
+            isSpecific: false,
+        },
+        category: 'Technical',
+        requires: [],
+    },
+    {
+        id: 'armorer',
+        label: 'SR5.Skill.Armorer',
+        skillGroupLabel: '',
+        specializations: [
+            'Armor',
+            'Artillery',
+            'Explosives',
+            'Firearms',
+            'Melee Weapons',
+            'Heavy Weapons',
+            'Weapon Accessories',
+        ],
+        linkedAttribute: 'logic',
+        flags: {
+            canDefault: true,
+            isSpecific: false,
+        },
+        category: 'Technical',
+        requires: [],
+    },
+    {
+        id: 'artisan',
+        label: 'SR5.Skill.Artisan',
+        skillGroupLabel: '',
+        specializations: ['By artisinal discipline'],
+        linkedAttribute: 'intuition',
+        flags: {
+            canDefault: false,
+            isSpecific: false,
+        },
+        category: 'Technical',
+        requires: [],
+    },
+    {
+        id: 'automotive_mechanic',
+        label: 'SR5.Skill.AutomotiveMechanic',
+        skillGroupLabel: 'SR5.SkillGroup.Engineering',
+        specializations: ['Walker', 'Hover', 'Tracked', 'Wheeled'],
+        linkedAttribute: 'logic',
+        flags: {
+            canDefault: false,
+            isSpecific: false,
+        },
+        category: 'Technical',
+        requires: [],
+    },
+    {
+        id: 'biotechnology',
+        label: 'SR5.Skill.Biotechnology',
+        skillGroupLabel: 'SR5.SkillGroup.Biotech',
+        specializations: ['Bioinformatics', 'Bioware', 'Cloning', 'Gene Therapy', 'Vat Maintenance'],
+        linkedAttribute: 'logic',
+        flags: {
+            canDefault: false,
+            isSpecific: false,
+        },
+        category: 'Technical',
+        requires: [],
+    },
+    {
+        id: 'chemistry',
+        label: 'SR5.Skill.Chemistry',
+        skillGroupLabel: '',
+        specializations: ['Analytical', 'Biochemistry', 'Inorganic', 'Organic', 'Physical'],
+        linkedAttribute: 'logic',
+        flags: {
+            canDefault: false,
+            isSpecific: false,
+        },
+        category: 'Technical',
+        requires: [],
+    },
+    {
+        id: 'computer',
+        label: 'SR5.Skill.Computer',
+        skillGroupLabel: 'SR5.SkillGroup.Electronics',
+        specializations: ['By Matrix Action'],
+        linkedAttribute: 'logic',
+        flags: {
+            canDefault: true,
+            isSpecific: false,
+        },
+        category: 'Technical',
+        requires: [],
+    },
+    {
+        id: 'cybercombat',
+        label: 'SR5.Skill.Cybercombat',
+        skillGroupLabel: 'SR5.SkillGroup.Cracking',
+        specializations: ['By cybercombat target type'],
+        linkedAttribute: 'logic',
+        flags: {
+            canDefault: true,
+            isSpecific: false,
+        },
+        category: 'Technical',
+        requires: [],
+    },
+    {
+        id: 'cybertechnology',
+        label: 'SR5.Skill.Cybertechnology',
+        skillGroupLabel: 'SR5.SkillGroup.Biotech',
+        specializations: ['Bodyware', 'Cyberlimbs', 'Headware', 'Repair'],
+        linkedAttribute: 'logic',
+        flags: {
+            canDefault: false,
+            isSpecific: false,
+        },
+        category: 'Technical',
+        requires: [],
+    },
+    {
+        id: 'demolitions',
+        label: 'SR5.Skill.Demolitions',
+        skillGroupLabel: '',
+        specializations: ['Commercial Explosives', 'Defusing', 'Improvised Explosives', 'Plastic Explosives'],
+        linkedAttribute: 'logic',
+        flags: {
+            canDefault: true,
+            isSpecific: false,
+        },
+        category: 'Technical',
+        requires: [],
+    },
+    {
+        id: 'electronic_warfare',
+        label: 'SR5.Skill.ElectronicWarfare',
+        skillGroupLabel: 'SR5.SkillGroup.Cracking',
+        specializations: ['Communications', 'Encryption', 'Jamming', 'Sensor Operations'],
+        linkedAttribute: 'logic',
+        flags: {
+            canDefault: false,
+            isSpecific: false,
+        },
+        category: 'Technical',
+        requires: [],
+    },
+    {
+        id: 'first_aid',
+        label: 'SR5.Skill.FirstAid',
+        skillGroupLabel: 'SR5.SkillGroup.Biotech',
+        specializations: ['By wound type'],
+        linkedAttribute: 'logic',
+        flags: {
+            canDefault: true,
+            isSpecific: false,
+        },
+        category: 'Technical',
+        requires: [],
+    },
+    {
+        id: 'forgery',
+        label: 'SR5.Skill.Forgery',
+        skillGroupLabel: '',
+        specializations: ['Counterfeiting', 'Credstick Forgery', 'False ID', 'Image Doctoring', 'Paper Forgery'],
+        linkedAttribute: 'logic',
+        flags: {
+            canDefault: true,
+            isSpecific: false,
+        },
+        category: 'Technical',
+        requires: [],
+    },
+    {
+        id: 'hacking',
+        label: 'SR5.Skill.Hacking',
+        skillGroupLabel: 'SR5.SkillGroup.Cracking',
+        specializations: ['Devices', 'Files', 'Hosts', 'Personas'],
+        linkedAttribute: 'logic',
+        flags: {
+            canDefault: true,
+            isSpecific: false,
+        },
+        category: 'Technical',
+        requires: [],
+    },
+    {
+        id: 'hardware',
+        label: 'SR5.Skill.Hardware',
+        skillGroupLabel: 'SR5.SkillGroup.Electronics',
+        specializations: ['By hardware type'],
+        linkedAttribute: 'logic',
+        flags: {
+            canDefault: false,
+            isSpecific: false,
+        },
+        category: 'Technical',
+        requires: [],
+    },
+    {
+        id: 'industrial_mechanic',
+        label: 'SR5.Skill.IndustrialMechanic',
+        skillGroupLabel: 'SR5.SkillGroup.Engineering',
+        specializations: [
+            'Electrical Power Systems',
+            'Hydraulics',
+            'HVAC',
+            'Industrial Robotics',
+            'Structural',
+            'Welding',
+        ],
+        linkedAttribute: 'logic',
+        flags: {
+            canDefault: false,
+            isSpecific: false,
+        },
+        category: 'Technical',
+        requires: [],
+    },
+    {
+        id: 'locksmith',
+        label: 'SR5.Skill.Locksmith',
+        skillGroupLabel: '',
+        specializations: ['By lock type'],
+        linkedAttribute: 'agility',
+        flags: {
+            canDefault: false,
+            isSpecific: false,
+        },
+        category: 'Technical',
+        requires: [],
+    },
+    {
+        id: 'medicine',
+        label: 'SR5.Skill.Medicine',
+        skillGroupLabel: 'SR5.SkillGroup.Biotech',
+        specializations: [
+            'Cosmetic Surgery',
+            'Extended Care',
+            'Implant Surgery',
+            'Magical Health',
+            'Organ Culture',
+            'Trauma Surgery',
+        ],
+        linkedAttribute: 'logic',
+        flags: {
+            canDefault: false,
+            isSpecific: false,
+        },
+        category: 'Technical',
+        requires: [],
+    },
+    {
+        id: 'nautical_mechanic',
+        label: 'SR5.Skill.NauticalMechanic',
+        skillGroupLabel: 'SR5.SkillGroup.Engineering',
+        specializations: ['Motorboat', 'Sailboat', 'Ship', 'Submarine'],
+        linkedAttribute: 'logic',
+        flags: {
+            canDefault: false,
+            isSpecific: false,
+        },
+        category: 'Technical',
+        requires: [],
+    },
+    {
+        id: 'navigation',
+        label: 'SR5.Skill.Navigation',
+        skillGroupLabel: 'SR5.SkillGroup.Outdoors',
+        specializations: ['Augmented Reality Markers', 'Celestial', 'Compass', 'Maps', 'GPS'],
+        linkedAttribute: 'intuition',
+        flags: {
+            canDefault: true,
+            isSpecific: false,
+        },
+        category: 'Technical',
+        requires: [],
+    },
+    {
+        id: 'software',
+        label: 'SR5.Skill.Software',
+        skillGroupLabel: 'SR5.SkillGroup.Electronics',
+        specializations: ['Data Bombs', 'By complex form'],
+        linkedAttribute: 'logic',
+        flags: {
+            canDefault: false,
+            isSpecific: false,
+        },
+        category: 'Technical',
+        requires: [],
+    },
+    {
+        id: 'gunnery',
+        label: 'SR5.Skill.Gunnery',
+        skillGroupLabel: '',
+        specializations: ['Artillery', 'Ballistic', 'Energy', 'Guided Missile', 'Rocket'],
+        linkedAttribute: 'agility',
+        flags: {
+            canDefault: true,
+            isSpecific: false,
+        },
+        category: 'Vehicle',
+        requires: [],
+    },
+    {
+        id: 'pilot_aerospace',
+        label: 'SR5.Skill.PilotAerospace',
+        skillGroupLabel: '',
+        specializations: ['Deep Space', 'Launch Craft', 'Remote Operation', 'Semiballistic', 'Suborbital'],
+        linkedAttribute: 'reaction',
+        flags: {
+            canDefault: false,
+            isSpecific: false,
+        },
+        category: 'Vehicle',
+        requires: [],
+    },
+    {
+        id: 'pilot_aircraft',
+        label: 'SR5.Skill.PilotAircraft',
+        skillGroupLabel: '',
+        specializations: [
+            'Fixed-Wing',
+            'Lighter-Than-Air',
+            'Remote Operation',
+            'Rotary Wing',
+            'Tilt Wing',
+            'Vectored Thrust',
+        ],
+        linkedAttribute: 'reaction',
+        flags: {
+            canDefault: false,
+            isSpecific: false,
+        },
+        category: 'Vehicle',
+        requires: [],
+    },
+    {
+        id: 'pilot_walker',
+        label: 'SR5.Skill.PilotWalker',
+        skillGroupLabel: '',
+        specializations: ['Biped', 'Multiped', 'Quadruped', 'Remote'],
+        linkedAttribute: 'reaction',
+        flags: {
+            canDefault: false,
+            isSpecific: false,
+        },
+        category: 'Vehicle',
+        requires: [],
+    },
+    {
+        id: 'pilot_exotic_vehicle',
+        label: 'SR5.Skill.PilotExoticVehicle',
+        skillGroupLabel: '',
+        specializations: [],
+        linkedAttribute: 'reaction',
+        flags: {
+            canDefault: false,
+            isSpecific: true,
+        },
+        category: 'Vehicle',
+        requires: [],
+    },
+    {
+        id: 'pilot_ground_craft',
+        label: 'SR5.Skill.PilotGroundCraft',
+        skillGroupLabel: '',
+        specializations: ['Bike', 'Hovercraft', 'Remote Operation', 'Tracked', 'Wheeled'],
+        linkedAttribute: 'reaction',
+        flags: {
+            canDefault: true,
+            isSpecific: false,
+        },
+        category: 'Vehicle',
+        requires: [],
+    },
+    {
+        id: 'pilot_water_craft',
+        label: 'SR5.Skill.PilotWaterCraft',
+        skillGroupLabel: '',
+        specializations: ['Hydrofoil', 'Motorboat', 'Remote Operation', 'Sail', 'Ship', 'Submarine'],
+        linkedAttribute: 'reaction',
+        flags: {
+            canDefault: true,
+            isSpecific: false,
+        },
+        category: 'Vehicle',
+        requires: [],
+    },
+    // Special skill for critters with the flight power CRB p394
+    {
+        id: 'flight',
+        label: 'SR5.Skill.Flight',
+        skillGroupLabel: 'SR5.SkillGroup.Athletics',
+        specializations: [],
+        linkedAttribute: 'agility',
+        flags: {
+            canDefault: true,
+            isSpecific: false,
+        },
+        category: 'Physical',
+        requires: [{ characterFlags: ['can-fly'] }],
+    },
+];
+
+// TODO?: implement maybe lazy loading
+export const ActiveSkillGroups: Record<string, ActiveSkillDefinition[]> = {};
+export const ActiveSkillsById: Record<string, ActiveSkillDefinition> = {};
+export const ActiveSkillCategories: Record<string, ActiveSkillDefinition[]> = {};
+
+for (const skill of ActiveSkillData) {
+    Object.freeze(skill);
+    ActiveSkillsById[skill.id] = skill;
+
+    const category = skill.category;
+    if (category) {
+        if (!ActiveSkillCategories[category]) ActiveSkillCategories[category] = [];
+        ActiveSkillCategories[category].push(skill);
+    }
+
+    const group = skill.skillGroupLabel;
+    if (group) {
+        if (!ActiveSkillGroups[group]) ActiveSkillGroups[group] = [];
+        ActiveSkillGroups[group].push(skill);
+    }
+}
+
+// Freeze the computed content
+Object.freeze(ActiveSkillData);
+Object.freeze(ActiveSkillGroups);
+Object.freeze(ActiveSkillsById);
+Object.freeze(ActiveSkillCategories);

--- a/src/module/handlebars/ItemLineHelpers.ts
+++ b/src/module/handlebars/ItemLineHelpers.ts
@@ -1,9 +1,10 @@
-import { SR5 } from "../config";
+import { SR5 } from '../config';
 import MarkedDocument = Shadowrun.MarkedDocument;
 import { InventorySheetDataByType } from '../actor/sheets/SR5BaseActorSheet';
 import { SR5ActiveEffect } from '../effect/SR5ActiveEffect';
 import { formatStrict } from '../utils/strings';
 import { SR5Item } from '../item/SR5Item';
+import { ActiveSkillsById } from '../config/ActiveSkills';
 
 /**
  * Typing around the legacy item list helper.
@@ -11,53 +12,54 @@ import { SR5Item } from '../item/SR5Item';
 interface ItemListRightSide {
     // Provide a simple text, main use for column headers.
     text?: {
-        text: string | number | undefined
-        title?: string // TODO: This doesn't seem to be doing anything in ListItem.html
-        cssClass?: string
-    }
+        text: string | number | undefined;
+        title?: string; // TODO: This doesn't seem to be doing anything in ListItem.html
+        cssClass?: string;
+    };
     // Provide a button element, main use for column values.
     button?: {
-        text: string | number
-        cssClass?: string
+        text: string | number;
+        cssClass?: string;
         // Shorten the button visually...
-        short?: boolean
-    }
+        short?: boolean;
+    };
     // Provide a input element, main use for column values.
     input?: {
-        type: string
-        value: any
-        cssClass?: string
-    }
+        type: string;
+        value: any;
+        cssClass?: string;
+    };
     // Provide html as string.
     html?: {
-        text: string
-        cssClass?: string
-    }
+        text: string;
+        cssClass?: string;
+    };
 }
 
 export const registerItemLineHelpers = () => {
     Handlebars.registerHelper('InventoryHeaderIcons', function (section: InventorySheetDataByType) {
         var icons = Handlebars.helpers['ItemHeaderIcons'](section.type) as object[];
 
-        icons.push(section.isOpen
-            ? {
-                icon: 'fas fa-square-chevron-up',
-                title: game.i18n.localize('SR5.Collapse'),
-                cssClass: 'item-toggle',
-                // Add HTML data attributes using a key<string>:value<string> structure
-                data: {}
-            }
-            : {
-                icon: 'fas fa-square-chevron-down',
-                title: game.i18n.localize('SR5.Expand'),
-                cssClass: 'item-toggle',
-                // Add HTML data attributes using a key<string>:value<string> structure
-                data: {}
-            }
+        icons.push(
+            section.isOpen
+                ? {
+                      icon: 'fas fa-square-chevron-up',
+                      title: game.i18n.localize('SR5.Collapse'),
+                      cssClass: 'item-toggle',
+                      // Add HTML data attributes using a key<string>:value<string> structure
+                      data: {},
+                  }
+                : {
+                      icon: 'fas fa-square-chevron-down',
+                      title: game.i18n.localize('SR5.Expand'),
+                      cssClass: 'item-toggle',
+                      // Add HTML data attributes using a key<string>:value<string> structure
+                      data: {},
+                  },
         );
 
         return icons;
-    })
+    });
 
     Handlebars.registerHelper('ItemHeaderIcons', function (type: string) {
         const PlusIcon = 'fas fa-plus';
@@ -68,7 +70,7 @@ export const registerItemLineHelpers = () => {
             title: formatStrict('SR5.Create', { type: 'SR5.Item' }),
             cssClass: 'item-create',
             // Add HTML data attributes using a key<string>:value<string> structure
-            data: {}
+            data: {},
         };
         switch (type) {
             case 'lifestyle':
@@ -168,7 +170,7 @@ export const registerItemLineHelpers = () => {
             title: formatStrict('SR5.Create', { type: 'SR5.Item' }),
             cssClass: 'inventory-item-create',
             // Add HTML data attributes using a key<string>:value<string> structure
-            data: { inventory: name }
+            data: { inventory: name },
         };
 
         return [addItemIcon];
@@ -287,23 +289,23 @@ export const registerItemLineHelpers = () => {
                 return [
                     {
                         text: {
-                            text: game.i18n.localize('SR5.CritterPower.Type')
-                        }
+                            text: game.i18n.localize('SR5.CritterPower.Type'),
+                        },
                     },
                     {
                         text: {
-                            text: game.i18n.localize('SR5.CritterPower.Range')
-                        }
+                            text: game.i18n.localize('SR5.CritterPower.Range'),
+                        },
                     },
                     {
                         text: {
-                            text: game.i18n.localize('SR5.CritterPower.Duration')
-                        }
+                            text: game.i18n.localize('SR5.CritterPower.Duration'),
+                        },
                     },
                     {
                         text: {
-                            text: game.i18n.localize('SR5.Rating')
-                        }
+                            text: game.i18n.localize('SR5.Rating'),
+                        },
                     },
                 ];
             case 'quality':
@@ -311,7 +313,7 @@ export const registerItemLineHelpers = () => {
                     {
                         text: {
                             text: game.i18n.localize('SR5.QualityType'),
-                        }
+                        },
                     },
                     {
                         text: {
@@ -326,72 +328,72 @@ export const registerItemLineHelpers = () => {
                 return [
                     {
                         text: {
-                            text: game.i18n.localize('SR5.Summoning.SpiritType')
-                        }
+                            text: game.i18n.localize('SR5.Summoning.SpiritType'),
+                        },
                     },
                     {
                         text: {
-                            text: game.i18n.localize('SR5.Force')
-                        }
-                    }
-                ]
+                            text: game.i18n.localize('SR5.Force'),
+                        },
+                    },
+                ];
             case 'compilation':
                 return [
                     {
                         text: {
-                            text: game.i18n.localize('SR5.Compilation.SpriteType')
-                        }
+                            text: game.i18n.localize('SR5.Compilation.SpriteType'),
+                        },
                     },
                     {
                         text: {
-                            text: game.i18n.localize('SR5.Level')
-                        }
-                    }
-                ]
+                            text: game.i18n.localize('SR5.Level'),
+                        },
+                    },
+                ];
 
             // General use case item lines
             case 'modifiers':
                 return [
                     {
                         text: {
-                            text: game.i18n.localize('SR5.Value')
-                        }
-                    }
-                ]
+                            text: game.i18n.localize('SR5.Value'),
+                        },
+                    },
+                ];
             case 'itemEffects':
                 return [
                     {
                         text: {
-                            text: game.i18n.localize('SR5.ActiveEffect.ApplyTo')
-                        }
+                            text: game.i18n.localize('SR5.ActiveEffect.ApplyTo'),
+                        },
                     },
                     {
                         text: {
-                            text: game.i18n.localize('SR5.Duration')
-                        }
+                            text: game.i18n.localize('SR5.Duration'),
+                        },
                     },
                     {
                         text: {
                             // Used as a placeholder for effect line icons.
                             // This way the header column is empty (as no +Add makes sense)
                             // However the line column contains the normal interaction icons.
-                            text: ''
-                        }
-                    }
-                ]
+                            text: '',
+                        },
+                    },
+                ];
             case 'effects':
                 return [
                     {
                         text: {
-                            text: game.i18n.localize('SR5.ActiveEffect.ApplyTo')
-                        }
+                            text: game.i18n.localize('SR5.ActiveEffect.ApplyTo'),
+                        },
                     },
                     {
                         text: {
-                            text: game.i18n.localize('SR5.Duration')
-                        }
-                    }
-                ]
+                            text: game.i18n.localize('SR5.Duration'),
+                        },
+                    },
+                ];
             default:
                 return [];
         }
@@ -441,13 +443,17 @@ export const registerItemLineHelpers = () => {
                     {
                         text: {
                             // Instead of 'complex' only show C. This might break in some languages. At that point, you can call me lazy.
-                            text: system.action.type ? game.i18n.localize(SR5.actionTypes[system.action.type] ?? '')[0] : ''
+                            text: system.action.type
+                                ? game.i18n.localize(SR5.actionTypes[system.action.type] ?? '')[0]
+                                : '',
                         },
                     },
                     {
                         text: {
                             // Either use the legacy skill localization OR just the skill name/id instead.
-                            text: game.i18n.localize(SR5.activeSkills[system.action.skill ?? ''] ?? system.action.skill),
+                            text: game.i18n.localize(
+                                ActiveSkillsById[system.action.skill ?? ''].label ?? system.action.skill,
+                            ),
                             cssClass: 'six',
                         },
                     },
@@ -460,7 +466,9 @@ export const registerItemLineHelpers = () => {
                     {
                         text: {
                             // Legacy actions could have both skill and attribute2 set, which would show both information, when it shouldn't.
-                            text: system.action.skill ? '' : game.i18n.localize(SR5.attributes[system.action.attribute2 ?? '']),
+                            text: system.action.skill
+                                ? ''
+                                : game.i18n.localize(SR5.attributes[system.action.attribute2 ?? '']),
                             cssClass: 'six',
                         },
                     },
@@ -487,24 +495,23 @@ export const registerItemLineHelpers = () => {
                     return [
                         {
                             text: {
-                                text: game.i18n.localize(SR5.modificationCategories[item.system.modification_category])
+                                text: game.i18n.localize(SR5.modificationCategories[item.system.modification_category]),
                             },
-
                         },
                         {
                             text: {
-                                text: item.system.slots || ''
+                                text: item.system.slots || '',
                             },
                         },
                         qtyInput,
                     ];
-                };
+                }
 
                 if (item.isType('modification') && item.system.type === 'drone') {
                     return [
                         {
                             text: {
-                                text: item.system.slots || ''
+                                text: item.system.slots || '',
                             },
                         },
                         qtyInput,
@@ -526,12 +533,13 @@ export const registerItemLineHelpers = () => {
                     const reloadLinks: ItemListRightSide[] = [];
 
                     // Show reload on both no ammo configured and partially consumed clips.
-                    const textReload = count < max ?
-                        `${game.i18n.localize('SR5.Weapon.Reload')} ` :
-                        `${game.i18n.localize('SR5.AmmoFull')}`;
-                        
+                    const textReload =
+                        count < max
+                            ? `${game.i18n.localize('SR5.Weapon.Reload')} `
+                            : `${game.i18n.localize('SR5.AmmoFull')}`;
+
                     const cssClassReload = 'no-break';
-                    
+
                     reloadLinks.push({
                         text: {
                             title: `${game.i18n.localize('SR5.Weapon.AmmoCount')}: `,
@@ -551,10 +559,12 @@ export const registerItemLineHelpers = () => {
                                 cssClass: cssClassFullReload,
                             },
                         });
-                    }       
+                    }
 
-                    if(count < max && partialReloadRounds > 0) {
-                        const textPartialReload = `${game.i18n.localize('SR5.Weapon.PartialReload')} (+${partialReloadRounds})`;
+                    if (count < max && partialReloadRounds > 0) {
+                        const textPartialReload = `${game.i18n.localize(
+                            'SR5.Weapon.PartialReload',
+                        )} (+${partialReloadRounds})`;
                         const cssClassPartialReload = 'no-break partial-reload-ammo roll';
 
                         reloadLinks.push({
@@ -564,10 +574,10 @@ export const registerItemLineHelpers = () => {
                                 cssClass: cssClassPartialReload,
                             },
                         });
-                    }       
+                    }
 
-                    reloadLinks.push(qtyInput)
-                    
+                    reloadLinks.push(qtyInput);
+
                     return reloadLinks;
                 } else {
                     return [qtyInput];
@@ -578,13 +588,13 @@ export const registerItemLineHelpers = () => {
                     {
                         text: {
                             text: game.i18n.localize(SR5.qualityTypes[item.system.type ?? '']),
-                        }
+                        },
                     },
                     {
                         text: {
                             text: item.system.rating || '',
                         },
-                    }
+                    },
                 ];
 
             case 'adept_power':
@@ -604,7 +614,9 @@ export const registerItemLineHelpers = () => {
                     },
                     {
                         text: {
-                            text: game.i18n.localize(SR5.spellRanges[(item.system as Item.SystemOfType<'spell'>).range ?? '']),
+                            text: game.i18n.localize(
+                                SR5.spellRanges[(item.system as Item.SystemOfType<'spell'>).range ?? ''],
+                            ),
                         },
                     },
                     {
@@ -622,24 +634,28 @@ export const registerItemLineHelpers = () => {
                 return [
                     {
                         text: {
-                            text: game.i18n.localize(SR5.critterPower.types[item.system.powerType ?? ''])
-                        }
+                            text: game.i18n.localize(SR5.critterPower.types[item.system.powerType ?? '']),
+                        },
                     },
                     {
                         text: {
-                            text: game.i18n.localize(SR5.critterPower.ranges[(item.system as Item.SystemOfType<'critter_power'>).range ?? ''])
-                        }
+                            text: game.i18n.localize(
+                                SR5.critterPower.ranges[
+                                    (item.system as Item.SystemOfType<'critter_power'>).range ?? ''
+                                ],
+                            ),
+                        },
                     },
                     {
                         text: {
-                            text: game.i18n.localize(SR5.critterPower.durations[item.system.duration ?? ''])
-                        }
+                            text: game.i18n.localize(SR5.critterPower.durations[item.system.duration ?? '']),
+                        },
                     },
                     {
                         text: {
-                            text: item.system.rating ?? ''
-                        }
-                    }
+                            text: item.system.rating ?? '',
+                        },
+                    },
                 ];
 
             case 'complex_form':
@@ -666,7 +682,9 @@ export const registerItemLineHelpers = () => {
                         button: {
                             cssClass: `item-equip-toggle ${item.isEquipped() ? 'light' : ''}`,
                             short: true,
-                            text: item.isEquipped() ? game.i18n.localize('SR5.Loaded') : game.i18n.localize('SR5.Load') + ' >>',
+                            text: item.isEquipped()
+                                ? game.i18n.localize('SR5.Loaded')
+                                : game.i18n.localize('SR5.Load') + ' >>',
                         },
                     },
                 ];
@@ -686,15 +704,15 @@ export const registerItemLineHelpers = () => {
                     return [
                         {
                             text: {
-                                text: game.i18n.localize(spiritTypeLabel)
-                            }
+                                text: game.i18n.localize(spiritTypeLabel),
+                            },
                         },
                         {
                             text: {
-                                text: summoningData.spirit.force
-                            }
-                        }
-                    ]
+                                text: summoningData.spirit.force,
+                            },
+                        },
+                    ];
                 }
 
                 if (item.system.actor_type === 'sprite') {
@@ -704,15 +722,15 @@ export const registerItemLineHelpers = () => {
                     return [
                         {
                             text: {
-                                text: game.i18n.localize(spriteTypeLabel)
-                            }
+                                text: game.i18n.localize(spriteTypeLabel),
+                            },
                         },
                         {
                             text: {
-                                text: compilationData.sprite.level
-                            }
-                        }
-                    ]
+                                text: compilationData.sprite.level,
+                            },
+                        },
+                    ];
                 }
 
             default:
@@ -737,7 +755,7 @@ export const registerItemLineHelpers = () => {
         const enableIcon = {
             icon: `${item.system.enabled ? 'fas fa-check-circle' : 'far fa-circle'} item-enable-toggle`,
             title: game.i18n.localize('SR5.ToggleEquip'),
-        }
+        };
         const pdfIcon = {
             icon: 'fas fa-file open-source',
             title: game.i18n.localize('SR5.OpenSource'),
@@ -759,12 +777,13 @@ export const registerItemLineHelpers = () => {
     Handlebars.registerHelper('EffectRightSide', function (effect: SR5ActiveEffect) {
         const getDurationLabel = () => {
             if (effect.duration.seconds) return `${effect.duration.seconds}s`;
-            if (effect.duration.rounds && effect.duration.turns) return `${effect.duration.rounds}r, ${effect.duration.turns}t`;
+            if (effect.duration.rounds && effect.duration.turns)
+                return `${effect.duration.rounds}r, ${effect.duration.turns}t`;
             if (effect.duration.rounds) return `${effect.duration.rounds}r`;
             if (effect.duration.turns) return `${effect.duration.turns}t`;
 
             return '';
-        }
+        };
 
         return [
             {
@@ -772,15 +791,15 @@ export const registerItemLineHelpers = () => {
                 text: {
                     text: game.i18n?.localize(SR5.effectApplyTo[effect.applyTo]),
                     cssClass: 'six',
-                }
+                },
             },
             {
                 // Duration Column
                 text: {
                     text: getDurationLabel(),
                     cssClass: 'six',
-                }
-            }
+                },
+            },
         ];
     });
 
@@ -788,7 +807,7 @@ export const registerItemLineHelpers = () => {
         const item = new SR5Item(itemStored as SR5Item);
         const moveIcon = {
             icon: 'fas fa-exchange-alt inventory-item-move',
-            title: game.i18n.localize('SR5.MoveItemInventory')
+            title: game.i18n.localize('SR5.MoveItemInventory'),
         };
         const editIcon = {
             icon: 'fas fa-edit item-edit',
@@ -824,23 +843,23 @@ export const registerItemLineHelpers = () => {
         const editIcon = {
             icon: 'fas fa-edit effect-control',
             title: game.i18n.localize('SR5.EditItem'),
-            data: { action: 'edit' }
+            data: { action: 'edit' },
         };
         const removeIcon = {
             icon: 'fas fa-trash effect-control',
             title: game.i18n.localize('SR5.DeleteItem'),
-            data: { action: 'delete' }
+            data: { action: 'delete' },
         };
         const disableIcon = {
             icon: `${effect.disabled ? 'far fa-circle' : 'fas fa-check-circle'} effect-control`,
             title: game.i18n.localize('SR5.ToggleActive'),
-            data: { action: "toggle" }
+            data: { action: 'toggle' },
         };
         const openOriginIcon = {
             icon: 'fas fa-file effect-control',
             title: game.i18n.localize('SR5.OpenOrigin'),
-            data: { action: "open-origin" }
-        }
+            data: { action: 'open-origin' },
+        };
         // Disallow changes to effects that aren't of direct origin.
         let icons = [disableIcon, editIcon, removeIcon];
         if (effect.isOriginOwned) icons = [openOriginIcon, ...icons];
@@ -854,17 +873,17 @@ export const registerItemLineHelpers = () => {
         const openOriginIcon = {
             icon: 'fas fa-file item-effect-control',
             title: game.i18n.localize('SR5.OpenOrigin'),
-            data: { action: "open-origin" }
-        }
+            data: { action: 'open-origin' },
+        };
         const disableIcon = {
             icon: `${effect.disabled ? 'far fa-circle' : 'fas fa-check-circle'} item-effect-control`,
             title: game.i18n.localize('SR5.ToggleActive'),
-            data: { action: "toggle" }
+            data: { action: 'toggle' },
         };
         const editIcon = {
             icon: 'fas fa-edit item-effect-control',
             title: game.i18n.localize('SR5.EditItem'),
-            data: { action: 'edit' }
+            data: { action: 'edit' },
         };
 
         return [openOriginIcon, disableIcon, editIcon];
@@ -879,7 +898,7 @@ export const registerItemLineHelpers = () => {
                 cssClass: 'marks-qty',
             },
         };
-        return [quantityInput]
+        return [quantityInput];
     });
 
     // Matrix Mark interaction on a Sheet.
@@ -887,13 +906,13 @@ export const registerItemLineHelpers = () => {
         const incrementIcon = {
             icon: 'fas fa-plus marks-add-one',
             title: game.i18n.localize('SR5.Labels.Sheet.AddOne'),
-            data: { action: 'add-one' }
+            data: { action: 'add-one' },
         };
         const decrementIcon = {
             icon: 'fas fa-minus marks-remove-one',
             title: game.i18n.localize('SR5.Labels.Sheet.SubtractOne'),
-            data: { action: 'remove-one' }
-        }
+            data: { action: 'remove-one' },
+        };
 
         return [incrementIcon, decrementIcon];
     });
@@ -914,16 +933,19 @@ export const registerItemLineHelpers = () => {
                 text: {
                     text: game.i18n.localize('SR5.Qty'),
                 },
-            }]
+            },
+        ];
     });
 
     Handlebars.registerHelper('MarkListHeaderIcons', () => {
-        return [{
-            icon: 'fas fa-trash',
-            title: game.i18n.localize('SR5.ClearMarks'),
-            text: game.i18n.localize('SR5.Del'),
-            cssClass: 'marks-clear-all'
-        }];
+        return [
+            {
+                icon: 'fas fa-trash',
+                title: game.i18n.localize('SR5.ClearMarks'),
+                text: game.i18n.localize('SR5.Del'),
+                cssClass: 'marks-clear-all',
+            },
+        ];
     });
 
     Handlebars.registerHelper('NetworkDevicesListRightSide', () => {
@@ -937,19 +959,22 @@ export const registerItemLineHelpers = () => {
                 text: {
                     text: game.i18n.localize('SR5.FOUNDRY.Item'),
                 },
-            }]
-    })
+            },
+        ];
+    });
 
     Handlebars.registerHelper('NetworkDevicesListHeaderIcons', () => {
-        return [{
-            icon: 'fas fa-trash',
-            title: game.i18n.localize('SR5.Labels.Sheet.ClearNetwork'),
-            text: game.i18n.localize('SR5.Del'),
-            cssClass: 'network-clear'
-        }];
-    })
+        return [
+            {
+                icon: 'fas fa-trash',
+                title: game.i18n.localize('SR5.Labels.Sheet.ClearNetwork'),
+                text: game.i18n.localize('SR5.Del'),
+                cssClass: 'network-clear',
+            },
+        ];
+    });
 
     Handlebars.registerHelper('EmptyIcons', () => {
         return [{}];
-    })
+    });
 };

--- a/src/module/types/template/Skills.ts
+++ b/src/module/types/template/Skills.ts
@@ -1,5 +1,7 @@
-import { ModifiableField } from "../fields/ModifiableField";
-import { ModifiableValue, KeyValuePair } from "./Base";
+import { ModifiableField } from '../fields/ModifiableField';
+import { ModifiableValue, KeyValuePair } from './Base';
+import { ActiveSkillData, type ActiveSkillDefinition } from 'src/module/config/ActiveSkills';
+
 const { SchemaField, BooleanField, ArrayField, StringField, TypedObjectField } = foundry.data.fields;
 
 export type SkillCategories = 'active' | 'language' | 'knowledge';
@@ -19,108 +21,43 @@ export const SkillField = () => ({
     group: new StringField({ required: true }),
 });
 
-function skill(createData: foundry.data.fields.SchemaField.CreateData<ReturnType<typeof SkillField>> = {}): SkillFieldType {
+function skill(
+    createData: foundry.data.fields.SchemaField.CreateData<ReturnType<typeof SkillField>> = {},
+): SkillFieldType {
     const initialValue = new ModifiableField(SkillField()).getInitialValue(createData);
     return foundry.utils.mergeObject(initialValue, createData) as SkillFieldType;
 }
 
-export const Skills = () => new TypedObjectField(
-    new ModifiableField(SkillField()),
-    {
-        required: true,
-        initial: {
-            // Combat Skills
-            archery: skill({ attribute: 'agility' }),
-            automatics: skill({ attribute: 'agility', group: 'Firearms' }),
-            blades: skill({ attribute: 'agility', group: 'Close Combat' }),
-            clubs: skill({ attribute: 'agility', group: 'Close Combat' }),
-            exotic_melee: skill({ attribute: 'agility', canDefault: false }), // how to deal with exotic melee weapons?
-            exotic_range: skill({ attribute: 'agility', canDefault: false }), // how to deal with exotic ranged weapons?
-            heavy_weapons: skill({ attribute: 'agility', group: 'Firearms' }),
-            longarms: skill({ attribute: 'agility', group: 'Firearms' }),
-            pistols: skill({ attribute: 'agility', group: 'Firearms' }),
-            throwing_weapons: skill({ attribute: 'agility', group: 'Close Combat' }),
-            unarmed_combat: skill({ attribute: 'agility', group: 'Close Combat' }),
-
-            // Physical Skills
-            disguise: skill({ attribute: 'intuition', group: 'Stealth' }),
-            diving: skill({ attribute: 'body' }),
-            escape_artist: skill({ attribute: 'agility' }),
-            flight: skill({ attribute: 'agility', canDefault: false, hidden: true }),
-            free_fall: skill({ attribute: 'body' }),
-            gymnastics: skill({ attribute: 'agility', group: 'Athletics' }),
-            palming: skill({ attribute: 'agility', group: 'Stealth', canDefault: false }),
-            perception: skill({ attribute: 'intuition' }),
-            running: skill({ attribute: 'strength', group: 'Athletics' }),
-            sneaking: skill({ attribute: 'agility', group: 'Stealth' }),
-            survival: skill({ attribute: 'willpower', group: 'Outdoors' }),
-            swimming: skill({ attribute: 'strength', group: 'Athletics' }),
-            tracking: skill({ attribute: 'intuition', group: 'Outdoors' }),
-
-            // Social Skills
-            con: skill({ attribute: 'charisma', group: 'Acting' }),
-            etiquette: skill({ attribute: 'charisma', group: 'Influence' }),
-            impersonation: skill({ attribute: 'charisma', group: 'Acting' }),
-            instruction: skill({ attribute: 'charisma' }),
-            intimidation: skill({ attribute: 'charisma' }),
-            leadership: skill({ attribute: 'charisma', group: 'Influence' }),
-            negotiation: skill({ attribute: 'charisma', group: 'Influence' }),
-            performance: skill({ attribute: 'charisma', group: 'Acting' }),
-
-            // Magic Skills
-            alchemy: skill({ attribute: 'magic', group: 'Enchanting', canDefault: false }),
-            arcana: skill({ attribute: 'logic', canDefault: false }),
-            artificing: skill({ attribute: 'magic', group: 'Enchanting', canDefault: false }),
-            assensing: skill({ attribute: 'intuition', canDefault: false }),
-            astral_combat: skill({ attribute: 'willpower', canDefault: false }),
-            banishing: skill({ attribute: 'magic', group: 'Conjuring', canDefault: false }),
-            binding: skill({ attribute: 'magic', group: 'Conjuring', canDefault: false }),
-            counterspelling: skill({ attribute: 'magic', group: 'Sorcery', canDefault: false }),
-            disenchanting: skill({ attribute: 'magic', group: 'Enchanting', canDefault: false }),
-            ritual_spellcasting: skill({ attribute: 'magic', group: 'Sorcery', canDefault: false }),
-            spellcasting: skill({ attribute: 'magic', group: 'Sorcery', canDefault: false }),
-            summoning: skill({ attribute: 'magic', group: 'Conjuring', canDefault: false }),
-
-            // Resonance Skills
-            compiling: skill({ attribute: 'resonance', group: 'Tasking', canDefault: false }),
-            decompiling: skill({ attribute: 'resonance', group: 'Tasking', canDefault: false }),
-            registering: skill({ attribute: 'resonance', group: 'Tasking', canDefault: false }),
-
-            // Technical Skills
-            aeronautics_mechanic: skill({ attribute: 'logic', group: 'Engineering', canDefault: false }),
-            automotive_mechanic: skill({ attribute: 'logic', group: 'Engineering', canDefault: false }),
-            industrial_mechanic: skill({ attribute: 'logic', group: 'Engineering', canDefault: false }),
-            nautical_mechanic: skill({ attribute: 'logic', group: 'Engineering', canDefault: false }),
-            animal_handling: skill({ attribute: 'charisma' }),
-            armorer: skill({ attribute: 'logic' }),
-            artisan: skill({ attribute: 'intuition', canDefault: false }),
-            biotechnology: skill({ attribute: 'logic', group: 'Biotech', canDefault: false }),
-            chemistry: skill({ attribute: 'logic', canDefault: false }),
-            computer: skill({ attribute: 'logic', group: 'Electronics' }),
-            cybercombat: skill({ attribute: 'logic', group: 'Cracking' }),
-            cybertechnology: skill({ attribute: 'logic', group: 'Biotech', canDefault: false }),
-            demolitions: skill({ attribute: 'logic' }),
-            electronic_warfare: skill({ attribute: 'logic', group: 'Cracking', canDefault: false }),
-            first_aid: skill({ attribute: 'logic', group: 'Biotech' }),
-            forgery: skill({ attribute: 'logic' }),
-            hacking: skill({ attribute: 'logic', group: 'Cracking' }),
-            hardware: skill({ attribute: 'logic', group: 'Electronics', canDefault: false }),
-            locksmith: skill({ attribute: 'logic', canDefault: false }),
-            medicine: skill({ attribute: 'logic', group: 'Biotech', canDefault: false }),
-            navigation: skill({ attribute: 'intuition', group: 'Outdoors' }),
-            software: skill({ attribute: 'logic', group: 'Electronics', canDefault: false }),
-
-            // Vehicle Skills
-            gunnery: skill({ attribute: 'agility' }),
-            pilot_aerospace: skill({ attribute: 'reaction', canDefault: false }),
-            pilot_aircraft: skill({ attribute: 'reaction', canDefault: false }),
-            pilot_walker: skill({ attribute: 'reaction', canDefault: false }),
-            pilot_ground_craft: skill({ attribute: 'reaction' }),
-            pilot_water_craft: skill({ attribute: 'reaction' }),
-            pilot_exotic_vehicle: skill({ attribute: 'reaction', canDefault: false }), // how to deal with exotic vehicles?
-        }
+function createSkillFromSkillData(skillDef: ActiveSkillDefinition) {
+    const { linkedAttribute, skillGroupLabel, flags, requires } = skillDef;
+    const options: any = {
+        attribute: linkedAttribute,
+    };
+    if (skillGroupLabel) {
+        const parts = skillGroupLabel.split('.');
+        // fix close combat; TODO: Remove this stuff, and reference the label directly
+        options.group = parts[parts.length - 1].replace(/([a-z])([A-Z])/g, '$1 $2');
     }
-);
+    if (!flags.canDefault) {
+        options.canDefault = false;
+    }
+
+    // fix flight
+    const needsFlight = requires?.[0]?.characterFlags?.includes('can-fly');
+    if (needsFlight) {
+        options.hidden = true;
+    }
+
+    return options;
+}
+
+export const Skills = () =>
+    new TypedObjectField(new ModifiableField(SkillField()), {
+        required: true,
+        initial: Object.fromEntries(
+            ActiveSkillData.map((skillDef) => [skillDef.id, skill(createSkillFromSkillData(skillDef))]),
+        ) as Record<string, ReturnType<typeof skill>>,
+    });
 
 console.log(Skills().getInitialValue());
 
@@ -128,9 +65,9 @@ export const KnowledgeSkillList = (initialAttribute: string) => ({
     attribute: new StringField({
         required: true,
         initial: initialAttribute,
-        choices: ["willpower", "logic", "intuition", "charisma"]
+        choices: ['willpower', 'logic', 'intuition', 'charisma'],
     }),
-    value: new TypedObjectField(new ModifiableField(SkillField()), {required: true, initial: {}}),
+    value: new TypedObjectField(new ModifiableField(SkillField()), { required: true, initial: {} }),
 });
 
 export const KnowledgeSkills = () => ({


### PR DESCRIPTION
- Move all active skill definitions to config/ActiveSkills.ts
- Update skill preparation and config to use ActiveSkillsById
- Refactor skill field schema to generate from ActiveSkillData
- Update helpers and flows to use new skill data source
- Remove legacy SR5.activeSkills from config

Tested it, seemed to work.